### PR TITLE
Updated instructions after testing on Ubuntu 14.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Before you start, you will need to install the appropriate tools, and configure 
 
 This setup requires ansible v1.9.3+ and boto. It is generally best to install these via python's ``pip`` tool.
 ```bash
-sudo apt-get install git python-pip
+sudo apt-get install git python-pip python-dev
 sudo pip install ansible boto awscli
 ```
 


### PR DESCRIPTION
Fixes issue #3, with steps that should work similarly on any Ubuntu version.
Tested on a fresh Ubuntu 14.04 LTS VM.

Note: an attempt was made to find proper packages that would be installable via apt.
There's no appropriate group of PPAs that will provide the versions we need.
