### PR TITLE
Use t2.large by default. Controller needs more RAM

### DIFF
--- a/romana-install/group_vars/all
+++ b/romana-install/group_vars/all
@@ -12,7 +12,7 @@ nw_romana_branch: "odwork"
 region: "us-west-1"
 key_name: "shared-key-1"
 # Devstack can install on "medium" or "large" instances, not "micro"
-instance_type: "t2.medium"
+instance_type: "t2.large"
 # Deployment currently targets Ubuntu 14.04 LTS 
 controller_image: "ami-df6a8b9b"
 compute_image: "ami-df6a8b9b"


### PR DESCRIPTION
Short-term fix for the controller running out of RAM after launching a very small number of instances.
