### PR TITLE
Fix for consoles

### DIFF
--- a/romana-install/config.yml
+++ b/romana-install/config.yml
@@ -4,10 +4,10 @@
     - name: Check for ec2_id_rsa
       file: path="~/.ssh/ec2_id_rsa" state=file mode=0600
     - name: Add Controller host(s)
-      add_host: name="{{ item }}" groups="controllers" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="~/.ssh/ec2_id_rsa"
+      add_host: name="{{ item }}" groups="stack_nodes,controllers" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="~/.ssh/ec2_id_rsa"
       with_items: groups["tag_automation_group_{{devstack_name}}_controller"] | default([])
     - name: Add Compute host(s)
-      add_host: name="{{ item }}" groups="computes" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="~/.ssh/ec2_id_rsa"
+      add_host: name="{{ item }}" groups="stack_nodes,computes" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="~/.ssh/ec2_id_rsa"
       with_items: groups["tag_automation_group_{{devstack_name}}_compute"] | default([])
     - name: Wait for SSH to be ready (controllers)
       wait_for: host="{{ item }}" port=22
@@ -16,10 +16,15 @@
       wait_for: host="{{ item }}" port=22
       with_items: groups.computes | default([])
 
-- hosts: controllers
+
+- hosts: stack_nodes
   connection: ssh
   roles:
     - os-common
+
+- hosts: controllers
+  connection: ssh
+  roles:
     - stack-controller
     - romana-common
     - romana-master
@@ -27,7 +32,6 @@
 - hosts: computes 
   connection: ssh
   roles:
-    - os-common
     - stack-compute
     - romana-common
 
@@ -36,12 +40,7 @@
   roles:
     - romana-demo-setup
 
-- hosts: controllers
-  connection: ssh
-  roles:
-    - romana-agent
-
-- hosts: computes
+- hosts: stack_nodes
   connection: ssh
   roles:
     - romana-agent

--- a/romana-install/group_vars/stack_nodes
+++ b/romana-install/group_vars/stack_nodes
@@ -1,0 +1,13 @@
+---
+stack_nodes:
+  Controller:
+    mgmt_ip: 192.168.0.10
+    public_ip: "{{ groups.controllers[0] }}"
+  Compute01:
+    mgmt_ip: 192.168.0.11
+  Compute02:
+    mgmt_ip: 192.168.0.12
+  Compute03:
+    mgmt_ip: 192.168.0.13
+  Compute04:
+    mgmt_ip: 192.168.0.14

--- a/romana-install/roles/generate-cloud/templates/devstack_lite_template.json
+++ b/romana-install/roles/generate-cloud/templates/devstack_lite_template.json
@@ -575,6 +575,10 @@
             "Value": "{{ devstack_name }}-controller"
           },
           {
+            "Key": "StackHost",
+            "Value": "Controller"
+          },
+          {
             "Key": "automation_group",
             "Value": "{{ devstack_name }}_controller"
           }
@@ -628,6 +632,10 @@
           {
             "Key": "Name",
             "Value": "{{ devstack_name }}-compute{{ node.suffix }}"
+          },
+          {
+            "Key": "StackHost",
+            "Value": "Compute{{ node.suffix }}"
           },
           {
             "Key": "automation_group",

--- a/romana-install/roles/stack-compute/templates/local.conf
+++ b/romana-install/roles/stack-compute/templates/local.conf
@@ -18,3 +18,9 @@ LDAP_PASSWORD="{{ devstack_password }}"
 SERVICE_TOKEN="{{ devstack_service_token }}"
 
 LOGFILE=stack.sh.log
+
+NOVA_VNC_ENABLED=True
+VNCSERVER_LISTEN="{{ stack_nodes[ec2_tag_StackHost].mgmt_ip }}"
+VNCSERVER_PROXYCLIENT_ADDRESS="{{ stack_nodes[ec2_tag_StackHost].mgmt_ip }}"
+NOVNCPROXY_URL="http://{{ stack_nodes.Controller.public_ip }}:6080/vnc_auto.html"
+

--- a/romana-install/roles/stack-controller/templates/local.conf
+++ b/romana-install/roles/stack-controller/templates/local.conf
@@ -27,7 +27,12 @@ LDAP_PASSWORD="{{ devstack_password }}"
 SERVICE_TOKEN="{{ devstack_service_token }}"
 
 NEUTRON_CREATE_INITIAL_NETWORKS=False
-NOVNCPROXY_URL="http://{{inventory_hostname}}:6080/vnc_auto.html"
+
+NOVA_VNC_ENABLED=True
+VNCSERVER_LISTEN="{{ stack_nodes[ec2_tag_StackHost].mgmt_ip }}"
+VNCSERVER_PROXYCLIENT_ADDRESS="{{ stack_nodes.Controller.mgmt_ip }}"
+NOVNCPROXY_URL="http://{{ stack_nodes.Controller.public_ip }}:6080/vnc_auto.html"
+
 LOGFILE=stack.sh.log
 
 [[post-config|$NEUTRON_CONF]]


### PR DESCRIPTION
This fixes #21 by providing the correct items in local.conf for the consoles.
Tested on a fresh stack, launched 2 instances and was able to open consoles for each one.

Needed to add more variables to get this functioning.
I'd like to merge this as-is (because functioning) and do a followup PR for tidying up variables and making it more consistent.
