### PR TITLE
Bashism in ansible shell commands. It silently succeeded on this.

### DIFF
--- a/romana-install/roles/romana-common/tasks/network.yml
+++ b/romana-install/roles/romana-common/tasks/network.yml
@@ -17,5 +17,5 @@
     - POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill
 
 - name: Enable kernel proxy_arp setting
-  shell: if [[ $(sysctl -n net.ipv4.conf.all.proxy_arp) != "1" ]]; then sysctl net.ipv4.conf.all.proxy_arp=1; fi
+  shell: if [ $(sysctl -n net.ipv4.conf.all.proxy_arp) != "1" ]; then sysctl net.ipv4.conf.all.proxy_arp=1; fi
 


### PR DESCRIPTION
```
changed: [54.67.29.44] => {"changed": true, "cmd": "if [[ $(sysctl -n net.ipv4.conf.all.proxy_arp) != \"1\" ]]; then sysctl net.ipv4.conf.all.proxy_arp=1; fi", "delta": "0:00:00.003583", "end": "2015-12-31 02:33:37.955291", "rc": 0, "start": "2015-12-31 02:33:37.951708", "stderr": "/bin/sh: 1: [[: not found", "stdout": "", "warnings": []}
```

Apparently that syntax error isn't worth failing a task for. Or the ubuntu "sh" doesn't actually error on it.
Either way, this silently succeeding meant that pings between VMs on hosts didn't work and the change corrects this.
