### PR TITLE
Patch checkout from openstack instead of using private clone

### DIFF
--- a/romana-install/roles/stack-common/files/nova-patch.sh
+++ b/romana-install/roles/stack-common/files/nova-patch.sh
@@ -1,0 +1,9 @@
+# nova-patch.sh
+
+if [[ "$1" == "stack" && "$2" == "install" ]]; then
+    if is_service_enabled nova; then
+        echo_summary "Patching nova module"
+        patch -d "$NOVA_DIR" -p1 < "$TOP_DIR/files/romana-nova-reschedule.patch"
+    fi
+fi
+

--- a/romana-install/roles/stack-common/files/romana-nova-reschedule.patch
+++ b/romana-install/roles/stack-common/files/romana-nova-reschedule.patch
@@ -1,0 +1,13 @@
+diff --git a/nova/virt/driver.py b/nova/virt/driver.py
+index 7ad53bf..8db7232 100644
+--- a/nova/virt/driver.py
++++ b/nova/virt/driver.py
+@@ -1135,7 +1135,7 @@ class ComputeDriver(object):
+ 
+     def deallocate_networks_on_reschedule(self, instance):
+         """Does the driver want networks deallocated on reschedule?"""
+-        return False
++        return True
+ 
+     def macs_for_instance(self, instance):
+         """What MAC addresses must this instance have?

--- a/romana-install/roles/stack-compute/tasks/devstack.yml
+++ b/romana-install/roles/stack-compute/tasks/devstack.yml
@@ -5,6 +5,12 @@
 - name: Install compute local.conf
   template: src=local.conf dest="~/devstack/local.conf"
 
+- name: Install extras script that patches nova
+  copy: src="../../stack-common/files/nova-patch.sh" dest="~/devstack/extras.d/91-nova-patch.sh" mode=0644
+
+- name: Install the patch that will be applied
+  copy: src="../../stack-common/files/romana-nova-reschedule.patch" dest="~/devstack/files/romana-nova-reschedule.patch" mode=0644
+
 - name: Run devstack "stack" script. This may take around 10 minutes.
   shell: chdir="~/devstack" creates="~/devstack/stack.sh.log" ./stack.sh
   async: 3600

--- a/romana-install/roles/stack-compute/templates/local.conf
+++ b/romana-install/roles/stack-compute/templates/local.conf
@@ -10,8 +10,6 @@ enable_service rabbit
 enable_service neutron
 enable_service q-dhcp
 
-NOVA_REPO=https://github.com/romana/nova.git
-
 ADMIN_PASSWORD="{{ devstack_password }}"
 SERVICE_PASSWORD="{{ devstack_password }}"
 DATABASE_PASSWORD="{{ devstack_password }}"

--- a/romana-install/roles/stack-controller/tasks/devstack.yml
+++ b/romana-install/roles/stack-controller/tasks/devstack.yml
@@ -5,6 +5,12 @@
 - name: Install controller local.conf
   template: src=local.conf dest="~/devstack/local.conf"
 
+- name: Install extras script that patches nova
+  copy: src="../../stack-common/files/nova-patch.sh" dest="~/devstack/extras.d/91-nova-patch.sh" mode=0644
+
+- name: Install the patch that will be applied
+  copy: src="../../stack-common/files/romana-nova-reschedule.patch" dest="~/devstack/files/romana-nova-reschedule.patch" mode=0644
+
 - name: Run devstack "stack" script. This may take 15-20 minutes.
   shell: chdir="~/devstack" creates="~/devstack/stack.sh.log" ./stack.sh
   async: 3600

--- a/romana-install/roles/stack-controller/templates/local.conf
+++ b/romana-install/roles/stack-controller/templates/local.conf
@@ -13,8 +13,6 @@ enable_service q-meta
 enable_service tempest
 enable_service neutron
 
-NOVA_REPO=https://github.com/romana/nova.git
-
 enable_service romana
 enable_plugin networking-romana git@github.com:romana/networking-romana{% if nw_romana_branch is defined %} {{ nw_romana_branch }}
 {% endif %}


### PR DESCRIPTION
This fixes a handful of scenarios in a cleaner way.

1) We don't need a private clone of nova. After 5 days, it's already 120 commits behind upstream.
2) We don't need to wrap nova services in a supervisor and relaunch. The change is applied during devstack setup rather than after it's completed.
3) Using a diff instead of a 'sed' command, it'll tolerate a certain amount of changes to the file on this branch and still succeed. (Sed would just fail silently if the line numbers being targeted were off)

It'll be great if upstream decide the change we're making is simply a bug and apply it to the upstream branches. That's sounding unlikely so I've not added comments/TODO in the scripts related to that.
