### PR TITLE
Change default security group to allow 192.168/16 and 10/8

### DIFF
--- a/romana-install/roles/generate-cf-template/templates/devstack_lite_template.json
+++ b/romana-install/roles/generate-cf-template/templates/devstack_lite_template.json
@@ -689,7 +689,11 @@ under the License.
         "SecurityGroupIngress": [
           {
             "IpProtocol": "-1",
-            "CidrIp": "192.168.0.0/24"
+            "CidrIp": "192.168.0.0/16"
+          },
+          {
+            "IpProtocol": "-1",
+            "CidrIp": "10.0.0.0/8"
           },
           {
             "IpProtocol": "icmp",


### PR DESCRIPTION
Tested, now can traceroute between VMs.

```
ubuntu@ip-192-168-0-10:~$ ssh cirros@10.0.19.3
The authenticity of host '10.0.19.3 (10.0.19.3)' can't be established.
RSA key fingerprint is 2b:ae:8e:14:e5:14:22:ef:8c:79:fd:80:5b:c1:fa:83.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '10.0.19.3' (RSA) to the list of known hosts.
$ ping     10.1.19.4
PING 10.1.19.4 (10.1.19.4): 56 data bytes
64 bytes from 10.1.19.4: seq=0 ttl=62 time=7.031 ms
64 bytes from 10.1.19.4: seq=1 ttl=62 time=1.529 ms
^C
--- 10.1.19.4 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 1.529/4.280/7.031 ms
$ traceroute     10.1.19.4
traceroute to 10.1.19.4 (10.1.19.4), 30 hops max, 46 byte packets
 1  ip-192-168-0-10 (192.168.0.10)  0.601 ms  0.045 ms  0.035 ms
 2  ip-192-168-0-11 (192.168.0.11)  0.656 ms  0.560 ms  1.253 ms
 3  10.1.19.4 (10.1.19.4)  3.651 ms  0.612 ms  0.698 ms
$ 
```
