### PR TITLE
Pull a pip cache from S3

### DIFF
--- a/romana-install/group_vars/all
+++ b/romana-install/group_vars/all
@@ -4,6 +4,7 @@ devstack_compute_nodes: 1
 devstack_password: "secrete"
 devstack_controller: "192.168.0.10"
 devstack_service_token: "eb24cc1eb0036c7971237850c767d9f6bae017a3"
+devstack_pip_cache: "root_pip_cache_stable-liberty_20160106.tar.gz"
 
 romana_dir: "/home/ubuntu/romana"
 romana_branch: "master"

--- a/romana-install/roles/stack-compute/tasks/devstack.yml
+++ b/romana-install/roles/stack-compute/tasks/devstack.yml
@@ -11,7 +11,7 @@
 - name: Install the patch that will be applied
   copy: src="../../stack-common/files/romana-nova-reschedule.patch" dest="~/devstack/files/romana-nova-reschedule.patch" mode=0644
 
-- name: Run devstack "stack" script. This may take around 10 minutes.
+- name: Run devstack "stack" script. This may take around 5 minutes.
   shell: chdir="~/devstack" creates="~/devstack/stack.sh.log" ./stack.sh
   async: 3600
   poll: 30

--- a/romana-install/roles/stack-compute/tasks/main.yml
+++ b/romana-install/roles/stack-compute/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: workarounds.yml
+- include: pip_cache.yml
   become: true
   become_user: root
 

--- a/romana-install/roles/stack-compute/tasks/pip_cache.yml
+++ b/romana-install/roles/stack-compute/tasks/pip_cache.yml
@@ -1,0 +1,6 @@
+---
+- name: Copy pip cache from S3 bucket
+  get_url: url="https://s3-us-west-1.amazonaws.com/romana-binaries/devstack/{{ devstack_pip_cache }}" dest="/var/tmp/{{ devstack_pip_cache }}" mode=0644
+
+- name: Unpack pip cache
+  unarchive: copy=no src="/var/tmp/{{ devstack_pip_cache }}" dest="/root/"

--- a/romana-install/roles/stack-controller/tasks/devstack.yml
+++ b/romana-install/roles/stack-controller/tasks/devstack.yml
@@ -11,7 +11,7 @@
 - name: Install the patch that will be applied
   copy: src="../../stack-common/files/romana-nova-reschedule.patch" dest="~/devstack/files/romana-nova-reschedule.patch" mode=0644
 
-- name: Run devstack "stack" script. This may take 15-20 minutes.
+- name: Run devstack "stack" script. This may take around 10 minutes.
   shell: chdir="~/devstack" creates="~/devstack/stack.sh.log" ./stack.sh
   async: 3600
   poll: 30

--- a/romana-install/roles/stack-controller/tasks/main.yml
+++ b/romana-install/roles/stack-controller/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: workarounds.yml
+- include: pip_cache.yml
   become: true
   become_user: root
 

--- a/romana-install/roles/stack-controller/tasks/pip_cache.yml
+++ b/romana-install/roles/stack-controller/tasks/pip_cache.yml
@@ -1,0 +1,6 @@
+---
+- name: Copy pip cache from S3 bucket
+  get_url: url="https://s3-us-west-1.amazonaws.com/romana-binaries/devstack/{{ devstack_pip_cache }}" dest="/var/tmp/{{ devstack_pip_cache }}" mode=0644
+
+- name: Unpack pip cache
+  unarchive: copy=no src="/var/tmp/{{ devstack_pip_cache }}" dest="/root/"


### PR DESCRIPTION
This speeds up the install by pulling a copy of the pip cache from S3.

That cache is from an earlier run, archived and pushed to S3.
This saves about 10 minutes from the total deployment time.
