### PR TITLE
Updating version to 0.6.0

### DIFF
--- a/romana-install/group_vars/all
+++ b/romana-install/group_vars/all
@@ -7,8 +7,8 @@ devstack_service_token: "eb24cc1eb0036c7971237850c767d9f6bae017a3"
 devstack_pip_cache: "root_pip_cache_stable-liberty_20160106.tar.gz"
 
 romana_dir: "/home/ubuntu/romana"
-romana_core_branch: "release-v0.6"
-romana_networking_branch: "stable/liberty"
+romana_core_branch: "v0.6.0"
+romana_networking_branch: "v0.6.0-stable/liberty"
 
 region: "us-west-1"
 key_name: "shared-key-1"


### PR DESCRIPTION
Although we already did the 0.6.0 release, this is the properly tagged and committed version of all that.
It's been done 'properly' now, in preparation for the 0.6.1 release.
(This prepares us for that, so we just need to merge, tag, re-test, and release.)

Behind the scenes:
- romana/core has a release-v0.6 branch and a tag for v0.6.0
- Jenkins has been reconfigured to build release tags and push them to S3
- networking-romana has branches that follow Openstack, so instead of a release branch and tag, there's a v0.6.0-master and a v0.6.0-stable/kilo tag. Not pretty but quite likely the least-ugly option.

One thought for the future: changelogs
