### PR TITLE
Provides a summary after completing installation.

### DIFF
--- a/romana-install/config.yml
+++ b/romana-install/config.yml
@@ -16,7 +16,6 @@
       wait_for: host="{{ item }}" port=22
       with_items: groups.computes | default([])
 
-
 - hosts: stack_nodes
   connection: ssh
   roles:
@@ -44,3 +43,8 @@
   connection: ssh
   roles:
     - romana-agent
+
+- hosts: localhost
+  connection: local
+  roles:
+    - stack-summary

--- a/romana-install/roles/stack-summary/tasks/main.yml
+++ b/romana-install/roles/stack-summary/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: "Generate Stack Summary"
+  template: src=stackinfo.txt dest=./stackinfo.txt
+

--- a/romana-install/roles/stack-summary/templates/stackinfo.txt
+++ b/romana-install/roles/stack-summary/templates/stackinfo.txt
@@ -1,0 +1,17 @@
+Devstack Summary
+================
+
+Controller
+----------
+{% for ip in groups["tag_automation_group_" + devstack_name + "_controller"] %}
+IP: {{ ip }}
+http://{{ ip }}
+(username: admin, password: {{ devstack_password }})
+ssh -i ~/.ssh/ec2_id_rsa ubuntu@{{ ip }}
+{% endfor %}
+
+Other Nodes
+-----------
+{% for ip in groups["tag_automation_group_" + devstack_name + "_compute"] %}
+ssh -i ~/.ssh/ec2_id_rsa ubuntu@{{ ip }}
+{% endfor %}

--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -100,7 +100,8 @@ case "$target" in
 		case "$action" in
 			install)
 				ansible-playbook "$@" -i /dev/null create.yml &&
-					ansible-playbook "$@" -i ec2.py config.yml
+					ansible-playbook "$@" -i ec2.py config.yml &&
+					[[ -f "stackinfo.txt" ]] && cat stackinfo.txt
 				;;
 			uninstall)
 				ansible-playbook "$@" -i /dev/null destroy.yml


### PR DESCRIPTION
Another feature I'd like to squeeze into 0.6.1 if it passes review.
Instead of ending with PLAY RECAP, it provides a final summary about what hosts have been set up.
The details are spaced-out a bit for easy copy-pasting URL or SSH commands.

``` bash-session
TASK: [stack-summary | Generate Stack Summary] ******************************** 
ok: [localhost]

PLAY RECAP ******************************************************************** 
54.183.4.170               : ok=34   changed=8    unreachable=0    failed=0   
54.67.125.80               : ok=49   changed=16   unreachable=0    failed=0   
localhost                  : ok=8    changed=0    unreachable=0    failed=0   

Devstack Summary
================

Controller
----------
IP: 54.67.125.80
http://54.67.125.80
(username: admin, password: secrete)
ssh -i ~/.ssh/ec2_id_rsa ubuntu@54.67.125.80

Other Nodes
-----------
ssh -i ~/.ssh/ec2_id_rsa ubuntu@54.183.4.170
```
