### PR TITLE
README changes across aws/vagrant/devstack/kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # The Romana Project
 
-[Romana](https://romana.io) is a new [Software Defined Network (SDN)](http://romana.io/cloud/cloud_native_sdn/) solution
-specifically designed for the Cloud Native architectural style. 
-The result of this focus is that Romana cloud networks are less expensive to build, 
-easier to operate and deliver higher performance than cloud networks built using alternative SDN designs.
+Romana is a new Software Defined Network solution specifically designed for Cloud Native applications. Romana allows multi-tenant cloud computing networks for OpenStack, Docker and Kubernetes to be built without encapsulation or a virtual network overlay.
+
+Romana networks are less expensive to build, easier to operate and deliver higher performance than networks built using alternative overlay based SDN designs.
 
 # Code
 

--- a/README.md
+++ b/README.md
@@ -1,193 +1,48 @@
 # The Romana Project
 
-Romana is a new Software Defined Network (SDN) solution specifically designed
-for the Cloud Native architectural style. The result of this focus is that
-Romana cloud networks are less expensive to build, easier to operate and
-deliver higher performance than cloud networks built using alternative SDN
-designs.
+[Romana](https://romana.io) is a new [Software Defined Network (SDN)](http://romana.io/cloud/cloud_native_sdn/) solution
+specifically designed for the Cloud Native architectural style. 
+The result of this focus is that Romana cloud networks are less expensive to build, 
+easier to operate and deliver higher performance than cloud networks built using alternative SDN designs.
 
-##  Getting Started
+# Code
 
-To get started with Romana running on Devstack, some scripts and Ansible
-playbooks have been provided to automate the setup and deployment, using
-[Amazon EC2 Instances](#romana-on-amazon-ec2-instances) or
-local [Virtualbox VMs](#romana-on-virtualbox-vms).
-The scripts and playbooks are located in this repository.
-They will access other repositories to download required pieces of the Romana system,
-as well as some binaries we have already pre-compiled for your convenience.
-
-The setup described below has been tested on Ubuntu 14.04 LTS, but should work
-similarly on other Linux or Mac OS X environments.
-
-## Romana on Amazon EC2 Instances
-
-Before you start, you will need to install the appropriate tools, and configure your EC2 SSH key and AWS credentials.
-
-### Prerequisites
-
-**Installing packages**
-
-This setup requires ansible v1.9.3+ and boto. It is generally best to install these via python's ``pip`` tool.
-```bash
-sudo apt-get install git python-pip python-dev
-sudo pip install ansible==1.9.4 boto awscli netaddr
-```
-
-**SSH key for access to EC2 instances**
-
-This setup expects your EC2 Private Key in `~/.ssh/ec2_id_rsa`
-
-**Setting up AWS tools**
-
-Configure awscli with your AWS Credentials.
-```sh-session
-$ aws configure
-AWS Access Key ID [None]: A*******************
-AWS Secret Access Key [None]: ****************************************
-Default region name [None]: us-west-1
-Default output format [None]: 
-```
-*Note:* The credentials provided should permit the creation of AWS resources such as EC2 instances, VPCs and so on.
-Ensure the IAM user or role for these credentials has permission to create these AWS resources.
-
-*Note:* The installation currently expects region ``us-west-1``, and might not work in other regions.
-This will be addressed in the future.
-
-
-### Installation
-
-Check out the Romana repository.
-```bash
-git clone https://github.com/romana/romana
-cd romana/romana-install
-```
-
-Edit the `group_vars/aws` file to specify the appropriate EC2 Key Name.
-Eg: change the `key_name` item from `shared-key-1` to the name you have configured.
-You can check the name in AWS by opening the EC2 dashboard, and selecting "Key Pairs" to see your list of Key pair names.
-
-Run the installer. This will create the Devstack cluster, install and activate Romana Cloud-Native tools.
-```bash
-./romana-setup
-```
-
-See details below about [using the system](#using-the-system) after the installation has completed.
-And [contact us](#getting-help) for more information or assistance.
-
-*Note:* By default, the stack name will be your username.
-If you prefer to use a different name for the stack, you can override this by providing an extra option when launching:
-```bash
-./romana-setup install -e stack_name=xyz
-```
-The name should be a single word, and only contain letters and numbers. (No hyphens, underscores, etc.)
-
-The EC2 installation takes 20-25 mins to complete (on t2.large instances) and creates an OpenStack DevStack cluster (Liberty release) with a single Controller Node and up to 4 additional Compute Nodes. Each OpenStack Node runs on a dedicated EC2 instance. Romana installs its OpenStack ML2 and IPAM drivers and creates a Romana router gateway interface on each Compute Node.
-
-By default, you will have one Controller and one additional Compute node. You can change the number of Compute nodes by editing `group_vars/all/stack` and providing a different value for `compute_nodes`.
-
-
-### Teardown
-
-To uninstall, use the 'uninstall' subcommand.
-```bash
-./romana-setup uninstall
-```
-
-## Romana on Virtualbox VMs
-
-You may wish to deploy this environment on your local machine using Virtualbox.
-Approximately 5GB of available RAM is required, mainly due to the Devstack Controller instance needing 4GB to function.
-
-### Prerequisites
-
-**Installing packages**
-
-This setup requires recent versions of
-- [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
-- [Vagrant](https://www.vagrantup.com/downloads.html)
-
-Also required are Ansible and the netaddr module. It is generally best to install these via python's ``pip`` tool.
-```bash
-sudo apt-get install git python-pip python-dev
-sudo pip install ansible==1.9.4 netaddr
-```
-
-Ensure the `vagrant` command can be run without specifying its full path.
-```sh-session
-$ type -P vagrant
-/usr/local/bin/vagrant
-```
-
-### Installation
-
-Check out the Romana repository.
-```bash
-git clone https://github.com/romana/romana
-cd romana/romana-install
-```
-
-Run the installer. This will create the Devstack cluster, install and activate Romana Cloud-Native tools.
-
-```bash
-./romana-setup -p vagrant
-```
-
-Installation will take a while, due to some large downloads, and long installation steps. Please be patient.
-
-You might want to take a [snapshot](https://www.virtualbox.org/manual/ch01.html#snapshots) of the VMs at this stage.
-
-### Teardown
-
-To uninstall, use the 'uninstall' subcommand.
-```bash
-./romana-setup -p vagrant uninstall
-```
-
-## Using The System
-
-At the end of installation, you should see a summary containing the URL of the dashboard,
-and SSH commands to use to connect to the instances.
-
-Other things you may wish to do:
-- launch an instance using Horizon:
-  * Log into the dashboard using username `admin` and password `secrete` (or the password you configured before installation)
-  * Select `Instances` from the `Project/Compute` sidebar
-  * Click the `Launch Instance` button
-  * Provide the required details
-  * Optionally, select the Advanced tab and specify a segment name in the `Romana Network Segment` field
-  * Click the Launch button
-- launch an instance using command-line: `nova boot --flavor m1.nano --image cirros-0.3.4-x86_64-uec --nic net-id=$(neutron net-show romana -Fid -f value) --meta romanaSegment=default instance-name`
-- connect to the instance: `ssh cirros@instance-ip`
-- install an ubuntu image:
-  * Create a new flavor with RAM:512MB, Disk: 3GB, VCPUs: 1: `nova flavor-create m1.smallish auto 512 3 1`
-  * Download a suitable image: `wget https://cloud-images.ubuntu.com/releases/14.04.3/release/ubuntu-14.04-server-cloudimg-amd64-disk1.img`
-  * Create image: `glance image-create --visibility public --disk-format qcow2 --container-format bare --name "ubuntu" < ubuntu-14.04-server-cloudimg-amd64-disk1.img`
-- register a new host: on the controller, run `romana add-host <hostname> <host-ip> <romana-cidr> <agent-port>`
-- add a new tenant: on the controller, run `romana create-tenant <tenant-name>`
-- add a new segment: on the controller, run `romana add-segment <tenant-name> <segment-name>`
-- see a list of tenants: `romana show-tenant`, details for a specific tenant: `romana show-tenant <tenant-name>`
-- see a list of hosts: `romana show-host`, details for a specific host: `romana show-host <hostname>`
-
-See also: [Try Romana Now](http://romana.io/try_romana/openstack/)
-
-## Working with the code
-
-This repository here contains the demo installer and documentation. The actual
-source code, however, is contained in these two repositories:
+This repository contains the installer and documentation.
+The Romana source code, however, is contained in these repositories:
 
 * [core](https://github.com/romana/core ): A number of micro services written in Go, which comprise the core components of the Romana system.
-* [networking-romana](https://github.com/romana/networking-romana): The Romana ML2 plugin an IPAM driver for OpenStack.
+* [kube](https://github.com/romana/kube): The Romana CNI plugin and Network Policy Agents for Kubernetes
+* [networking-romana](https://github.com/romana/networking-romana): The Romana ML2 plugin and IPAM driver for OpenStack
 
-The READMEs of those repos contain more information about the source code and
-how to run and test it.
+The READMEs of those repos contain more information about the source code and how to run and test it.
 
-## Getting help
+#  Installation
 
-There are a number of ways in which you can contact us if you have any
-questions about deploying or using Romana or about contributing to our code.
+To get up and running with Romana, some scripts and Ansible playbooks have been provided to automate the setup and deployment.
+It currently supports [Amazon EC2](https://aws.amazon.com/ec2/) instances and [Vagrant](https://www.vagrantup.com/) VMs,
+integrated with either [Kubernetes](http://kubernetes.io) or [Devstack](http://docs.openstack.org/developer/devstack/).
 
-* By email: [info@romana.io](mailto:info@romana.io).
-* Via our [Romana developer mailing list](https://groups.google.com/forum/?hl=en#!forum/romana-dev).
-* Via our [Romana user mailing list](https://groups.google.com/forum/?hl=en#!forum/romana-user).
-* On the [Romana Slack channel](https://romana.slack.com/). Please note that you will need an invite for this channel. Please contact us [by email](mailto:info@romana.io) to request an invite.
+* [Romana on AWS EC2 with Kubernetes](aws_kubernetes.md)
+* [Romana on AWS EC2 with Devstack](aws_devstack.md)
+* [Romana on Vagrant VMs with Kubernetes](vagrant_kubernetes.md)
+* [Romana on Vagrant VMs with Devstack](vagrant_devstack.md)
 
+Additional installation platforms are being targeted.
+You can express your interest in specific platforms or get help with manually installing Romana by [contacting us](#contact-us).
+
+# Using Romana
+
+Now that Romana is installed, choose your stack type below for more information on what you can do.
+
+* [Romana with Kubernetes](kubernetes_romana.md)
+* [Romana with Devstack](devstack_romana.md)
+
+# Contact Us
+
+There are a number of ways in which you can contact us if you have any questions about deploying or using Romana,
+or about contributing to our code.
+
+* By email: [info@romana.io](mailto:info@romana.io)
+* Via our [Romana developer mailing list](https://groups.google.com/forum/?hl=en#!forum/romana-dev)
+* Via our [Romana user mailing list](https://groups.google.com/forum/?hl=en#!forum/romana-user)
+* On the [Romana Slack channel](https://romana.slack.com/). Please note that you will need an invite for this channel. Please contact us [by email](mailto:info@romana.io) to request an invite

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ The READMEs of those repos contain more information about the source code and ho
 #  Installation
 
 To get up and running with Romana, some scripts and Ansible playbooks have been provided to automate the setup and deployment.
-It currently supports [Amazon EC2](https://aws.amazon.com/ec2/) instances and [Vagrant](https://www.vagrantup.com/) VMs,
-integrated with either [Kubernetes](http://kubernetes.io) or [Devstack](http://docs.openstack.org/developer/devstack/).
+This can be used to set up a cluster for experimenting with Romana, exploring how it works and learning how it interacts with Kubernetes and/or Openstack.
+
+The installer is currently capable of setting up a stand-alone [Kubernetes](http://kubernetes.io) or [OpenStack-Devstack](http://docs.openstack.org/developer/devstack/) cluster.
+As deployment targets for those clusters, it supports [Amazon EC2](https://aws.amazon.com/ec2/) or local  [Vagrant](https://www.vagrantup.com/) VMs.
 
 * [Romana on AWS EC2 with Kubernetes](aws_kubernetes.md)
 * [Romana on AWS EC2 with Devstack](aws_devstack.md)
@@ -32,7 +34,8 @@ You can express your interest in specific platforms or get help with manually in
 
 # Using Romana
 
-Now that Romana is installed, choose your stack type below for more information on what you can do.
+Once you have Romana installed and running in a cluster, you might like to test its capabilities and see it in action.
+The two links below give you cluster specific suggestions of what to try and what to explore and look at.
 
 * [Romana with Kubernetes](kubernetes_romana.md)
 * [Romana with Devstack](devstack_romana.md)

--- a/aws_devstack.md
+++ b/aws_devstack.md
@@ -66,11 +66,11 @@ Controller
 IP: 52.xx.yy.zz
 http://52.xx.yy.zz
 (username: admin, password: secrete)
-ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+ssh -i /.../romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
 
 Other Nodes
 -----------
-ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
 ```
 
 You can now proceed to [Using Romana on Devstack](romana_devstack.md).

--- a/aws_devstack.md
+++ b/aws_devstack.md
@@ -1,0 +1,85 @@
+# Installing Romana on AWS EC2 with Devstack
+
+The setup described below has been tested on Ubuntu 14.04 LTS, but should work similarly on other Linux or Mac OS X environments.
+You may need to install additional development tools.
+
+If you do not wish to install additional tools in your host, you can create a VM and execute the installation steps from there.
+
+# Prepare
+
+To run this installation, you will need
+* an AWS account. You can create one at [http://aws.amazon.com](http://aws.amazon.com)
+* credentials for an [AWS IAM](https://console.aws.amazon.com/iam/home) User/Role that permits creating EC2 instances
+* [ansible](https://www.ansible.com) and supporting python tools / libraries
+
+## Set up Ansible
+
+```bash
+# Ubuntu
+sudo apt-get install git python-pip python-dev
+sudo pip install ansible==1.9.4 boto awscli netaddr
+
+# OS X
+sudo easy_install pip
+sudo pip install ansible==1.9.4 boto awscli netaddr
+```
+
+## Set up AWS tools
+
+```bash
+aws configure
+```
+
+This will prompt you for your AWS Access Key ID, AWS Secret Key ID and Region.
+
+```sh-session
+AWS Access Key ID [None]: A*******************
+AWS Secret Access Key [None]: ****************************************
+Default region name [None]: us-west-1
+Default output format [None]: 
+```
+
+## (Optional) Set up EC2 Key Pair
+
+If the servers will be accessed by people using an [EC2 Key Pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html), apply the additional configuration step.
+```bash
+# Configure 'shared-key-1' as the EC2 Key Pair used by the installer
+echo "shared-key-1" > ~/.aws/ec2_keypair
+```
+
+# Install
+
+Check out the Romana repository and run the installer
+```bash
+git clone https://github.com/romana/romana
+cd romana/romana-install
+./romana-setup -p aws -s devstack install
+```
+
+The EC2 installation takes 20-25 mins to complete, and creates a Devstack cluster with two nodes. When installation is complete, information about the cluster should be provided.
+```sh-session
+Devstack Summary
+================
+
+Controller
+----------
+IP: 52.xx.yy.zz
+http://52.xx.yy.zz
+(username: admin, password: secrete)
+ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+
+Other Nodes
+-----------
+ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+```
+
+You can now proceed to [Using Romana on Devstack](romana_devstack.md).
+
+# Uninstall
+
+From the same directory, you can perform an uninstall
+```bash
+./romana-setup -p aws -s devstack install
+```
+
+This will destroy the Devstack cluster.

--- a/aws_devstack.md
+++ b/aws_devstack.md
@@ -10,18 +10,18 @@ If you do not wish to install additional tools in your host, you can create a VM
 To run this installation, you will need
 * an AWS account. You can create one at [http://aws.amazon.com](http://aws.amazon.com)
 * credentials for an [AWS IAM](https://console.aws.amazon.com/iam/home) User/Role that permits creating EC2 instances
-* [ansible](https://www.ansible.com) and supporting python tools / libraries
+* [ansible](https://www.ansible.com) v1.9.4 or higher, and supporting python tools / libraries
 
 ## Set up Ansible
 
 ```bash
 # Ubuntu
 sudo apt-get install git python-pip python-dev
-sudo pip install ansible==1.9.4 boto awscli netaddr
+sudo pip install ansible boto awscli netaddr
 
 # OS X
 sudo easy_install pip
-sudo pip install ansible==1.9.4 boto awscli netaddr
+sudo pip install ansible boto awscli netaddr
 ```
 
 ## Set up AWS tools

--- a/aws_kubernetes.md
+++ b/aws_kubernetes.md
@@ -10,18 +10,18 @@ If you do not wish to install additional tools in your host, you can create a VM
 To run this installation, you will need
 * an AWS account. You can create one at [http://aws.amazon.com](http://aws.amazon.com)
 * credentials for an [AWS IAM](https://console.aws.amazon.com/iam/home) User/Role that permits creating EC2 instances
-* [ansible](https://www.ansible.com) and supporting python tools / libraries
+* [ansible](https://www.ansible.com) v1.9.4 or higher, and supporting python tools / libraries
 
 ## Set up Ansible
 
 ```bash
 # Ubuntu
 sudo apt-get install git python-pip python-dev
-sudo pip install ansible==1.9.4 boto awscli netaddr
+sudo pip install ansible boto awscli netaddr
 
 # OS X
 sudo easy_install pip
-sudo pip install ansible==1.9.4 boto awscli netaddr
+sudo pip install ansible boto awscli netaddr
 ```
 
 ## Set up AWS tools

--- a/aws_kubernetes.md
+++ b/aws_kubernetes.md
@@ -1,0 +1,83 @@
+# Installing Romana on AWS EC2 with Kubernetes
+
+The setup described below has been tested on Ubuntu 14.04 LTS, but should work similarly on other Linux or Mac OS X environments.
+You may need to install additional development tools.
+
+If you do not wish to install additional tools in your host, you can create a VM and execute the installation steps from there.
+
+# Prepare
+
+To run this installation, you will need
+* an AWS account. You can create one at [http://aws.amazon.com](http://aws.amazon.com)
+* credentials for an [AWS IAM](https://console.aws.amazon.com/iam/home) User/Role that permits creating EC2 instances
+* [ansible](https://www.ansible.com) and supporting python tools / libraries
+
+## Set up Ansible
+
+```bash
+# Ubuntu
+sudo apt-get install git python-pip python-dev
+sudo pip install ansible==1.9.4 boto awscli netaddr
+
+# OS X
+sudo easy_install pip
+sudo pip install ansible==1.9.4 boto awscli netaddr
+```
+
+## Set up AWS tools
+
+```bash
+aws configure
+```
+
+This will prompt you for your AWS Access Key ID, AWS Secret Key ID and Region.
+
+```sh-session
+AWS Access Key ID [None]: A*******************
+AWS Secret Access Key [None]: ****************************************
+Default region name [None]: us-west-1
+Default output format [None]: 
+```
+
+## (Optional) Set up EC2 Key Pair
+
+If the servers will be accessed by people using an [EC2 Key Pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html), apply the additional configuration step.
+```bash
+# Configure 'shared-key-1' as the EC2 Key Pair used by the installer
+echo "shared-key-1" > ~/.aws/ec2_keypair
+```
+
+# Install
+
+Check out the Romana repository and run the installer
+```bash
+git clone https://github.com/romana/romana
+cd romana/romana-install
+./romana-setup -p aws -s kubernetes install
+```
+
+The EC2 installation takes 20-25 mins to complete, and creates a Kubernetes cluster with two nodes. When installation is complete, information about the cluster should be provided.
+```sh-session
+Kubernetes Summary
+==================
+
+Master
+------
+IP: 52.xx.yy.zz
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+
+Minions
+-------
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+```
+
+You can now proceed to [Using Romana on Kubernetes](romana_kubernetes.md).
+
+# Uninstall
+
+From the same directory, you can perform an uninstall
+```bash
+./romana-setup -p aws -s kubernetes install
+```
+
+This will destroy the Kubernetes cluster.

--- a/devstack_romana.md
+++ b/devstack_romana.md
@@ -10,7 +10,7 @@ These can be used to log into the host using the generated SSH key. Use the SSH 
 
 ## Look up information
 
-A `romana` tool has been provided that lets you see details about the setup, and make changes.
+A `romana` command-line tool has been provided that lets you see details about the setup, and make changes.
 ```sh-session
 ubuntu@ip-192-168-99-10:~$ romana show-hosts
 Listing 2 host(s)
@@ -21,7 +21,7 @@ ip-192-168-99-10       192.168.99.10        10.0.0.1/16     0
 ubuntu@ip-192-168-99-10:~$ romana show-host ip-192-168-99-11
 ip-192-168-99-11       192.168.99.11        10.1.0.1/16     0
 ```
-By default, we have two hosts (`192.168.99.10` and `192.168.99.11`). Each host has its own CIDR (`10.0.0.1/16`, `10.1.0.1/16`) that it will use when allocating IP addresses.
+By default, we have two hosts (`192.168.99.10` and `192.168.99.11`). Each host has its own CIDR (`10.0.0.1/16`, `10.1.0.1/16`) that Romana will use when allocating IP addresses to OpenStack guests on that host.
 
 ```sh-session
 ubuntu@ip-192-168-99-10:~$ romana show-tenants
@@ -33,7 +33,7 @@ Tenant:c858ac6ab9534f8f86f2fe9a731277e1 (admin)
 Segments: default, s1, s2
 ```
 
-We've also created `admin` and `demo` tenants, with segments. If the `admin` user creates a new instance, it needs to provide a named segment.
+We've also created `admin` and `demo` tenants, with segments. If a new instance is created for a tenant, a segment name needs to be provided.
 This will create an IP address within that segment and configure `iptables` rules to restrict communication to hosts within that segment.
 
 ## Create a new instance
@@ -64,7 +64,8 @@ ubuntu@ip-192-168-99-10:~$ nova list
 
 ```
 
-A new instance was created, and has IP `10.0.17.3`. You can SSH into this from the host it was created on.
+A new instance was created, and the IP address `10.0.17.3` was assigned to it. You can SSH into this from the host it was created on.
+We can also see from the IP address's network prefix (`10.0/16`) that this instance was created on host `ip-192-168-99-10`. (See the `romana show-host` details above.)
 
 ```
 ubuntu@ip-192-168-99-10:~$ ssh cirros@10.0.17.3
@@ -87,7 +88,7 @@ Make changes to the setup using the `romana` CLI tool.
 - Add new tenants: `romana create-tenant <name>` (name should exist in Openstack)
 - Add new segments: `romana add-segment <tenant-name> <segment-name>
 
-After creating things, they should be immediately available for use when creating new instances.
+After adding new segments, they can be used when booting new instances via nova.
 
-To experience the segment isolation, create instances inside the same segment and in different tenants.
-Then, log into one of them and see what other instances are reachable.
+To experience the segment isolation, create instances inside the same segment and in different segments or even for different tenants.
+You will notice that they cannot contact each other, while instances within the same segment can communicate just fine.

--- a/devstack_romana.md
+++ b/devstack_romana.md
@@ -1,0 +1,93 @@
+# Using Romana on Devstack
+
+When installation completes, some SSH commands are provided for logging into your new hosts, eg:
+```bash
+ssh -i /.../romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+```
+
+These can be used to log into the host using the generated SSH key. Use the SSH command for the controller to log in.
+
+## Look up information
+
+A `romana` tool has been provided that lets you see details about the setup, and make changes.
+```sh-session
+ubuntu@ip-192-168-99-10:~$ romana show-hosts
+Listing 2 host(s)
+ip-192-168-99-10
+ip-192-168-99-11
+ubuntu@ip-192-168-99-10:~$ romana show-host ip-192-168-99-10
+ip-192-168-99-10       192.168.99.10        10.0.0.1/16     0
+ubuntu@ip-192-168-99-10:~$ romana show-host ip-192-168-99-11
+ip-192-168-99-11       192.168.99.11        10.1.0.1/16     0
+```
+By default, we have two hosts (`192.168.99.10` and `192.168.99.11`). Each host has its own CIDR (`10.0.0.1/16`, `10.1.0.1/16`) that it will use when allocating IP addresses.
+
+```sh-session
+ubuntu@ip-192-168-99-10:~$ romana show-tenants
+Listing 2 tenant(s)
+c858ac6ab9534f8f86f2fe9a731277e1 (admin)
+7b593643644243e48915acd98df7b0d0 (demo)
+ubuntu@ip-192-168-99-10:~$ romana show-tenant admin
+Tenant:c858ac6ab9534f8f86f2fe9a731277e1 (admin)
+Segments: default, s1, s2
+```
+
+We've also created `admin` and `demo` tenants, with segments. If the `admin` user creates a new instance, it needs to provide a named segment.
+This will create an IP address within that segment and configure `iptables` rules to restrict communication to hosts within that segment.
+
+## Create a new instance
+
+When creating an instance, you should provide additional metadata to specify the segment that the instance should be allocated into.
+```sh-session
+ubuntu@ip-192-168-99-10:~$ nova boot --flavor m1.nano --image cirros-0.3.4-x86_64-uec --key-name shared-key --nic net-id=$(neutron net-show romana -Fid -f value) --meta romanaSegment=default example-instance
++--------------------------------------+----------------------------------------------------------------+
+| Property                             | Value                                                          |
++--------------------------------------+----------------------------------------------------------------+
+| ...                                  |                                                                |
+| created                              | 2016-03-02T22:46:38Z                                           |
+| flavor                               | m1.nano (42)                                                   |
+| ...                                  |                                                                |
+| id                                   | 048054fe-ec19-45ff-a679-83c19ebb5026                           |
+| image                                | cirros-0.3.4-x86_64-uec (c11f6cde-7bb8-40ed-bce8-fedf676ef1ff) |
+| ...                                  |                                                                |
+| metadata                             | {"romanaSegment": "default"}                                   |
+| name                                 | example-instance                                               |
+| ...                                  |                                                                |
++--------------------------------------+----------------------------------------------------------------+
+ubuntu@ip-192-168-99-10:~$ nova list
++--------------------------------------+------------------+--------+------------+-------------+------------------+
+| ID                                   | Name             | Status | Task State | Power State | Networks         |
++--------------------------------------+------------------+--------+------------+-------------+------------------+
+| 048054fe-ec19-45ff-a679-83c19ebb5026 | example-instance | ACTIVE | -          | Running     | romana=10.0.17.3 |
++--------------------------------------+------------------+--------+------------+-------------+------------------+
+
+```
+
+A new instance was created, and has IP `10.0.17.3`. You can SSH into this from the host it was created on.
+
+```
+ubuntu@ip-192-168-99-10:~$ ssh cirros@10.0.17.3
+The authenticity of host '10.0.17.3 (10.0.17.3)' can't be established.
+RSA key fingerprint is f6:2a:53:3c:e6:62:62:52:6b:17:ba:53:23:1f:c8:3d.
+Are you sure you want to continue connecting (yes/no)? yes
+Warning: Permanently added '10.0.17.3' (RSA) to the list of known hosts.
+$ 
+```
+
+## Details
+
+- See what `iptables` were configured: `sudo iptables -nL`
+- Log files: these are in `/var/log/upstart/`
+
+## Experiment
+
+Make changes to the setup using the `romana` CLI tool.
+- Add new hosts: `romana add-host <hostname> <host-ip> <romana-cidr> <agent-port>`
+- Add new tenants: `romana create-tenant <name>` (name should exist in Openstack)
+- Add new segments: `romana add-segment <tenant-name> <segment-name>
+
+After creating things, they should be immediately available for use when creating new instances.
+
+To experience the segment isolation, create instances inside the same segment and in different tenants.
+Then, log into one of them and see what other instances are reachable.

--- a/devstack_romana.md
+++ b/devstack_romana.md
@@ -78,7 +78,8 @@ $
 
 ## Details
 
-- See what `iptables` were configured: `sudo iptables -nL`
+- See what `iptables` routes were configured: `sudo iptables -nL`
+- See routes that were configured: `ip route`
 - Log files: these are in `/var/log/upstart/`
 
 ## Experiment

--- a/devstack_romana.md
+++ b/devstack_romana.md
@@ -84,7 +84,6 @@ $
 ## Experiment
 
 Make changes to the setup using the `romana` CLI tool.
-- Add new hosts: `romana add-host <hostname> <host-ip> <romana-cidr> <agent-port>`
 - Add new tenants: `romana create-tenant <name>` (name should exist in Openstack)
 - Add new segments: `romana add-segment <tenant-name> <segment-name>
 

--- a/devstack_romana.md
+++ b/devstack_romana.md
@@ -30,7 +30,7 @@ c858ac6ab9534f8f86f2fe9a731277e1 (admin)
 7b593643644243e48915acd98df7b0d0 (demo)
 ubuntu@ip-192-168-99-10:~$ romana show-tenant admin
 Tenant:c858ac6ab9534f8f86f2fe9a731277e1 (admin)
-Segments: default, s1, s2
+Segments: default, frontend, backend
 ```
 
 We've also created `admin` and `demo` tenants, with segments. If a new instance is created for a tenant, a segment name needs to be provided.

--- a/kubernetes_romana.md
+++ b/kubernetes_romana.md
@@ -1,0 +1,68 @@
+# Using Romana on Kubernetes
+
+When installation completes, some SSH commands are provided for logging into your new hosts, eg:
+```bash
+ssh -i /.../romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+```
+
+These can be used to log into the host using the generated SSH key. Use the SSH command for the master to log in.
+
+## Run a scripted demo
+
+We've provided a scripted demo, for a quick introduction to Romana on Kubernetes. Use this command to run it.
+```bash
+ubuntu@ip-192-168-99-10:~$ ./demo/demo.sh 
+```
+
+Press Enter to proceed through the steps.
+
+## Look up information
+
+A `romana` tool has been provided that lets you see details about the setup, and make changes.
+```sh-session
+ubuntu@ip-192-168-99-10:~$ romana show-hosts
+Listing 2 host(s)
+ip-192-168-99-10
+ip-192-168-99-11
+ubuntu@ip-192-168-99-10:~$ romana show-host ip-192-168-99-10
+ip-192-168-99-10       192.168.99.10        10.0.0.1/16     0
+ubuntu@ip-192-168-99-10:~$ romana show-host ip-192-168-99-11
+ip-192-168-99-11       192.168.99.11        10.1.0.1/16     0
+```
+By default, we have two hosts (`192.168.99.10` and `192.168.99.11`). Each host has its own CIDR (`10.0.0.1/16`, `10.1.0.1/16`) that it will use when allocating IP addresses.
+
+```sh-session
+ubuntu@ip-192-168-99-10:~$ romana show-owners
+Listing 2 owner(s)
+t1                              
+t2                              
+ubuntu@ip-192-168-99-10:~$ romana show-owner t1
+owner:t1                              
+tiers: default, backend, frontend
+ubuntu@ip-192-168-99-10:~$ romana show-owner t2
+owner:t2                              
+tiers: default
+ubuntu@ip-192-168-99-10:~$ 
+```
+
+We've also created `t1` and `t2` owners with tiers within them. `t1` has three tiers, and `t2` only has a default tier.
+When creating new pods, this configuration is used to help construct an IP address within the CIDR allocated to the host.
+
+## Creating new pods
+
+See the example `yaml` files in the `demo` folder. Romana is operating behind-the-scenes of Kubernetes, and gets notified about pods being created, allocating IP addresses and configuring `iptables` rules.
+
+## Details
+
+- See what `iptables` were configured: `sudo iptables -nL`
+- Log files: these are in `/var/log/upstart/`
+
+## Experiment
+
+Make changes to the setup using the `romana` CLI tool.
+- Add new hosts: `romana add-host <hostname> <host-ip> <romana-cidr> <agent-port>`
+- Add new owners: `romana create-owner <name>`
+- Add new tiers: `romana add-tier <owner> <tier-name>
+
+After creating things, they should be immediately available for use when creating new pods within Kubernetes.

--- a/kubernetes_romana.md
+++ b/kubernetes_romana.md
@@ -19,7 +19,7 @@ Press Enter to proceed through the steps.
 
 ## Look up information
 
-A `romana` tool has been provided that lets you see details about the setup, and make changes.
+A `romana` command-line tool has been provided that lets you see details about the setup, and make changes.
 ```sh-session
 ubuntu@ip-192-168-99-10:~$ romana show-hosts
 Listing 2 host(s)
@@ -30,7 +30,7 @@ ip-192-168-99-10       192.168.99.10        10.0.0.1/16     0
 ubuntu@ip-192-168-99-10:~$ romana show-host ip-192-168-99-11
 ip-192-168-99-11       192.168.99.11        10.1.0.1/16     0
 ```
-By default, we have two hosts (`192.168.99.10` and `192.168.99.11`). Each host has its own CIDR (`10.0.0.1/16`, `10.1.0.1/16`) that it will use when allocating IP addresses.
+By default, we have two hosts (`192.168.99.10` and `192.168.99.11`). Each host has its own CIDR (`10.0.0.1/16`, `10.1.0.1/16`) that Romana will use when allocating IP addresses to Kubernetes pods on that host.
 
 ```sh-session
 ubuntu@ip-192-168-99-10:~$ romana show-owners
@@ -65,4 +65,4 @@ Make changes to the setup using the `romana` CLI tool.
 - Add new owners: `romana create-owner <name>`
 - Add new tiers: `romana add-tier <owner> <tier-name>
 
-After creating things, they should be immediately available for use when creating new pods within Kubernetes.
+

--- a/kubernetes_romana.md
+++ b/kubernetes_romana.md
@@ -55,7 +55,8 @@ See the example `yaml` files in the `demo` folder. Romana is operating behind-th
 
 ## Details
 
-- See what `iptables` were configured: `sudo iptables -nL`
+- See what `iptables` rules were configured: `sudo iptables -nL`
+- See routes that were configured: `ip route`
 - Log files: these are in `/var/log/upstart/`
 
 ## Experiment

--- a/kubernetes_romana.md
+++ b/kubernetes_romana.md
@@ -65,4 +65,6 @@ Make changes to the setup using the `romana` CLI tool.
 - Add new owners: `romana create-owner <name>`
 - Add new tiers: `romana add-tier <owner> <tier-name>
 
+These owners and tiers can be used when creating Kubernetes resources using kubectl.
 
+Look into the demo script and resources (`.yaml` files) in `~/demo` to see how owners and tiers are applied to Kubernetes resources.

--- a/kubernetes_romana.md
+++ b/kubernetes_romana.md
@@ -61,7 +61,6 @@ See the example `yaml` files in the `demo` folder. Romana is operating behind-th
 ## Experiment
 
 Make changes to the setup using the `romana` CLI tool.
-- Add new hosts: `romana add-host <hostname> <host-ip> <romana-cidr> <agent-port>`
 - Add new owners: `romana create-owner <name>`
 - Add new tiers: `romana add-tier <owner> <tier-name>
 

--- a/vagrant_devstack.md
+++ b/vagrant_devstack.md
@@ -42,11 +42,11 @@ Controller
 IP: 52.xx.yy.zz
 http://52.xx.yy.zz
 (username: admin, password: secrete)
-ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
 
 Other Nodes
 -----------
-ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
 ```
 
 You can now proceed to [Using Romana on Devstack](romana_devstack.md).

--- a/vagrant_devstack.md
+++ b/vagrant_devstack.md
@@ -1,0 +1,61 @@
+# Installing Romana on Vagrant with Devstack
+
+The setup described below has been tested on Ubuntu 14.04 LTS, but should work similarly on other Linux or Mac OS X environments.
+You may need to install additional development tools.
+
+This should be done on your host. A 'run from a VM' option is being developed, for users that do not wish to install additional tools on the host.
+
+# Prepare
+
+To run this installation, you will need
+* [Vagrant](https://www.vagrantup.com/downloads.html) installed (and [tested](https://www.vagrantup.com/docs/getting-started/) to be sure it works)
+* [ansible](https://www.ansible.com) and supporting python tools / libraries
+
+## Set up Ansible
+
+```bash
+# Ubuntu
+sudo apt-get install git python-pip python-dev
+sudo pip install ansible==1.9.4 netaddr
+
+# OS X
+sudo easy_install pip
+sudo pip install ansible==1.9.4 netaddr
+```
+
+# Install
+
+Check out the Romana repository and run the installer
+```bash
+git clone https://github.com/romana/romana
+cd romana/romana-install
+./romana-setup -p vagrant -s devstack install
+```
+
+The Vagrant installation can take a long time to complete, because of some large downloads that are performed. Please be patient. When installation is complete, information about the cluster should be provided.
+```sh-session
+Devstack Summary
+================
+
+Controller
+----------
+IP: 52.xx.yy.zz
+http://52.xx.yy.zz
+(username: admin, password: secrete)
+ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@52.xx.yy.zz
+
+Other Nodes
+-----------
+ssh -i /Users/cgilmour/Development/romana/romana/romana-install/romana_id_rsa ubuntu@54.zz.yy.xx
+```
+
+You can now proceed to [Using Romana on Devstack](romana_devstack.md).
+
+# Uninstall
+
+From the same directory, you can perform an uninstall
+```bash
+./romana-setup -p vagrant -s devstack install
+```
+
+This will destroy the Devstack cluster.

--- a/vagrant_devstack.md
+++ b/vagrant_devstack.md
@@ -9,18 +9,18 @@ This should be done on your host. A 'run from a VM' option is being developed, f
 
 To run this installation, you will need
 * [Vagrant](https://www.vagrantup.com/downloads.html) installed (and [tested](https://www.vagrantup.com/docs/getting-started/) to be sure it works)
-* [ansible](https://www.ansible.com) and supporting python tools / libraries
+* [ansible](https://www.ansible.com) v1.9.4 or higher, and supporting python tools / libraries
 
 ## Set up Ansible
 
 ```bash
 # Ubuntu
 sudo apt-get install git python-pip python-dev
-sudo pip install ansible==1.9.4 netaddr
+sudo pip install ansible netaddr
 
 # OS X
 sudo easy_install pip
-sudo pip install ansible==1.9.4 netaddr
+sudo pip install ansible netaddr
 ```
 
 # Install

--- a/vagrant_kubernetes.md
+++ b/vagrant_kubernetes.md
@@ -1,0 +1,59 @@
+# Installing Romana on Vagrant with Kubernetes
+
+The setup described below has been tested on Ubuntu 14.04 LTS, but should work similarly on other Linux or Mac OS X environments.
+You may need to install additional development tools.
+
+This should be done on your host. A 'run from a VM' option is being developed, for users that do not wish to install additional tools on the host.
+
+# Prepare
+
+To run this installation, you will need
+* [Vagrant](https://www.vagrantup.com/downloads.html) installed (and [tested](https://www.vagrantup.com/docs/getting-started/) to be sure it works)
+* [ansible](https://www.ansible.com) and supporting python tools / libraries
+
+## Set up Ansible
+
+```bash
+# Ubuntu
+sudo apt-get install git python-pip python-dev
+sudo pip install ansible==1.9.4 netaddr
+
+# OS X
+sudo easy_install pip
+sudo pip install ansible==1.9.4 netaddr
+```
+
+# Install
+
+Check out the Romana repository and run the installer
+```bash
+git clone https://github.com/romana/romana
+cd romana/romana-install
+./romana-setup -p vagrant -s kubernetes install
+```
+
+The Vagrant installation can take a long time to complete, because of some large downloads that are performed. Please be patient. When installation is complete, information about the cluster should be provided.
+```sh-session
+Kubernetes Summary
+==================
+
+Master
+------
+IP: 192.168.99.10
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@192.168.99.10
+
+Minions
+-------
+ssh -i /.../romana/romana-install/romana_id_rsa ubuntu@192.168.99.11
+```
+
+You can now proceed to [Using Romana on Kubernetes](romana_kubernetes.md).
+
+# Uninstall
+
+From the same directory, you can perform an uninstall
+```bash
+./romana-setup -p vagrant -s kubernetes install
+```
+
+This will destroy the Kubernetes cluster.

--- a/vagrant_kubernetes.md
+++ b/vagrant_kubernetes.md
@@ -9,18 +9,18 @@ This should be done on your host. A 'run from a VM' option is being developed, f
 
 To run this installation, you will need
 * [Vagrant](https://www.vagrantup.com/downloads.html) installed (and [tested](https://www.vagrantup.com/docs/getting-started/) to be sure it works)
-* [ansible](https://www.ansible.com) and supporting python tools / libraries
+* [ansible](https://www.ansible.com) v1.9.4 or higher, and supporting python tools / libraries
 
 ## Set up Ansible
 
 ```bash
 # Ubuntu
 sudo apt-get install git python-pip python-dev
-sudo pip install ansible==1.9.4 netaddr
+sudo pip install ansible netaddr
 
 # OS X
 sudo easy_install pip
-sudo pip install ansible==1.9.4 netaddr
+sudo pip install ansible netaddr
 ```
 
 # Install


### PR DESCRIPTION
Since this is a replacement / overwrite of the existing docs, it might make sense to review just the files, instead of the diff between the earlier README.
This is something that should be dropped in at the same time as the updated installer.
I've put it on a separate branch to try and keep the changes clear.

Once reviewed and OKed, it'll get merged to `kubernetes` then `kubernetes` merged to `master`.