### PR TITLE
Feature/namespace per tenant

### DIFF
--- a/kubernetes/DEMO.md
+++ b/kubernetes/DEMO.md
@@ -138,7 +138,7 @@ logout
 
 Create network policy object to allow access from nginx-frontend to nginx-backend
 ```
-root@ip-192-168-0-10:/home/ubuntu# curl -X POST -d @romana/kubernetes/romana-network-policy-request.json http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/tenantA/networkpolicys/
+root@ip-192-168-0-10:/home/ubuntu# curl -X POST -d @romana/kubernetes/romana-network-policy-request.json http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/tenant-a/networkpolicys/
 {
   "apiVersion": "romana.io/demo/v1",
   "kind": "NetworkPolicy",

--- a/kubernetes/DEMO.md
+++ b/kubernetes/DEMO.md
@@ -144,7 +144,7 @@ root@ip-192-168-0-10:/home/ubuntu# curl -X POST -d @romana/kubernetes/romana-net
   "kind": "NetworkPolicy",
   "metadata": {
     "name": "pol1",
-    "namespace": "tenantA",
+    "namespace": "tenant-a",
     "selfLink": "/apis/romana.io/demo/v1/namespaces/default/networkpolicys/pol1",
     "uid": "262fd5e3-d109-11e5-8078-06f9d64b8ea3",
     "resourceVersion": "307",
@@ -211,5 +211,5 @@ Commercial support is available at
 
 Thats how you can delete policy 
 ```
-curl -X DELETE  http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/tenantA/networkpolicys/pol1
+curl -X DELETE  http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/tenant-a/networkpolicys/pol1
 ```

--- a/kubernetes/DEMO.md
+++ b/kubernetes/DEMO.md
@@ -23,6 +23,7 @@ replicationcontroller "nginx-default" created
 
 Start example pods for another tenant
 ```
+root@ip-192-168-0-10:/home/ubuntu# kubectl create -f romana/kubernetes/isolated-namespace.yaml
 root@ip-192-168-0-10:/home/ubuntu# kubectl create -f romana/kubernetes/pod-frontend.yaml 
 pod "nginx-frontend" created
 ```
@@ -137,13 +138,13 @@ logout
 
 Create network policy object to allow access from nginx-frontend to nginx-backend
 ```
-root@ip-192-168-0-10:/home/ubuntu# curl -X POST -d @romana/kubernetes/romana-network-policy-request.json http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/default/networkpolicys/
+root@ip-192-168-0-10:/home/ubuntu# curl -X POST -d @romana/kubernetes/romana-network-policy-request.json http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/tenantA/networkpolicys/
 {
   "apiVersion": "romana.io/demo/v1",
   "kind": "NetworkPolicy",
   "metadata": {
     "name": "pol1",
-    "namespace": "default",
+    "namespace": "tenantA",
     "selfLink": "/apis/romana.io/demo/v1/namespaces/default/networkpolicys/pol1",
     "uid": "262fd5e3-d109-11e5-8078-06f9d64b8ea3",
     "resourceVersion": "307",
@@ -210,5 +211,5 @@ Commercial support is available at
 
 Thats how you can delete policy 
 ```
-curl -X DELETE  http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/default/networkpolicys/pol1
+curl -X DELETE  http://192.168.0.10:8080/apis/romana.io/demo/v1/namespaces/tenantA/networkpolicys/pol1
 ```

--- a/kubernetes/isolated-namespace.yaml
+++ b/kubernetes/isolated-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "tenant-a"
+  labels:
+    name: "tenant-a"
+  annotations:
+    net.alpha.kubernetes.io/network-isolation: "on"

--- a/kubernetes/pod-backend.yaml
+++ b/kubernetes/pod-backend.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-backend
-  namespace: tenantA
+  namespace: tenant-a
   labels:
     app: nginx
     segment: backend

--- a/kubernetes/pod-backend.yaml
+++ b/kubernetes/pod-backend.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-backend
+  namespace: tenantA
   labels:
     app: nginx
-    owner: t1
-    tier: backend
+    segment: backend
 spec:
   containers:
   - name: nginx

--- a/kubernetes/pod-frontend.yaml
+++ b/kubernetes/pod-frontend.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-frontend
+  namespace: tenantA
   labels:
     app: nginx
-    owner: t1
-    tier: frontend
+    segment: frontend
 spec:
   containers:
   - name: nginx

--- a/kubernetes/pod-frontend.yaml
+++ b/kubernetes/pod-frontend.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-frontend
-  namespace: tenantA
+  namespace: tenant-a
   labels:
     app: nginx
     segment: frontend

--- a/kubernetes/romana-network-policy-request.json
+++ b/kubernetes/romana-network-policy-request.json
@@ -1,15 +1,12 @@
 {
    "metadata": {
-     "name" : "pol1",
-     "labels":{
-        "owner":"t1"
-     }
+     "name" : "pol1"
    },
    "apiVersion" : "romana.io/demo/v1",
    "kind" : "NetworkPolicy",
    "spec" : { 
                "podSelector" : { 
-                    "tier" : "backend" 
+                    "segment" : "backend" 
                 },
                 "allowIncoming" : {
                     "toPorts" : [
@@ -21,7 +18,7 @@
                     "from" : [
 			{
 			   "pods" : {
-				"tier" : "frontend"
+				"segment" : "frontend"
 	                   }
 			}
                     ]

--- a/kubernetes/romana.sqldump
+++ b/kubernetes/romana.sqldump
@@ -912,7 +912,7 @@ CREATE TABLE `tenants` (
 
 LOCK TABLES `tenants` WRITE;
 /*!40000 ALTER TABLE `tenants` DISABLE KEYS */;
-INSERT INTO `tenants` VALUES (1,'default',1),(2,'tenantA',2);
+INSERT INTO `tenants` VALUES (1,'default',1),(2,'tenant-a',2);
 /*!40000 ALTER TABLE `tenants` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/kubernetes/romana.sqldump
+++ b/kubernetes/romana.sqldump
@@ -912,7 +912,7 @@ CREATE TABLE `tenants` (
 
 LOCK TABLES `tenants` WRITE;
 /*!40000 ALTER TABLE `tenants` DISABLE KEYS */;
-INSERT INTO `tenants` VALUES (1,'t1',1),(2,'t2',2);
+INSERT INTO `tenants` VALUES (1,'default',1),(2,'tenantA',2);
 /*!40000 ALTER TABLE `tenants` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
* 1:1 Mapping between kube namespaces and romana tenants.
* Default tenant named 'default' in romana.sqldump - to accomodate default namespace and allow kube example to work out of the box.
* updated demo resources and DEMO.md to work in isolated namespace

