### PR TITLE
Install kube-ui as part of a demo setup

### DIFF
--- a/romana-install/config.yml
+++ b/romana-install/config.yml
@@ -19,16 +19,17 @@
 - hosts: controller
   roles:
     - romana/install-master
+    - romana/postinstall
+
+# Install and launch agent
+- hosts: stack_nodes
+  roles:
+    - romana/install-agent
 
 # Include romana+stack playbooks. Only the configured stack will be applied
 - include: romana.devstack.yml
 # - include: romana.openstack.yml
 - include: romana.kubernetes.yml
-
-# Install and launch agent (must be after other stages)
-- hosts: stack_nodes
-  roles:
-    - romana/install-agent
 
 # Generate a summary
 - hosts: localhost

--- a/romana-install/roles/provision/create-aws-hosts/templates/aws_cf_small_cluster.json
+++ b/romana-install/roles/provision/create-aws-hosts/templates/aws_cf_small_cluster.json
@@ -734,13 +734,23 @@ under the License.
             "FromPort": 80,
             "ToPort": 80,
             "IpProtocol": "tcp"
-          },
+          }
+{%- if stack_type == "devstack" %},
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": "6080",
             "ToPort": "6080",
             "IpProtocol": "tcp"
           }
+{% endif %}
+{%- if stack_type == "kubernetes" %},
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": "8080",
+            "ToPort": "8080",
+            "IpProtocol": "tcp"
+          }
+{% endif %}
 	],
         "Tags": [
           {

--- a/romana-install/roles/romana/devstack-postinstall/tasks/main.yml
+++ b/romana-install/roles/romana/devstack-postinstall/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-# Make sure the bin directory exists
-- file: path="/home/ubuntu/bin/" mode=0775 state=directory
-
 # Ensure the jq tool is installed
 - apt: pkg="jq"
   become: true
@@ -10,12 +7,9 @@
 - name: Update ubuntu profile
   patch: src="ubuntu_profile_add_openrc.patch" basedir="/home/ubuntu"
 
-- name: Install romana tool
-  template: src="../cmd/romana.ds" dest="/home/ubuntu/bin/romana" mode=0775
-
-- name: Install romana post-install script
-  template: src="romana-post-install.sh" dest="/var/tmp/romana-post-install.sh" mode=0755
+- name: Install devstack post-install script
+  template: src="devstack-post-install.sh" dest="/var/tmp/devstack-post-install.sh" mode=0755
         
-- name: Execute romana post-install script
-  shell: /var/tmp/romana-post-install.sh
+- name: Execute devstack post-install script
+  shell: /var/tmp/devstack-post-install.sh
 

--- a/romana-install/roles/romana/devstack-postinstall/templates/devstack-post-install.sh
+++ b/romana-install/roles/romana/devstack-postinstall/templates/devstack-post-install.sh
@@ -22,15 +22,6 @@ fi
 # Suppress output
 exec > /dev/null
 
-# This script currently directly uses the REST API of the Romana Topology and Tenant services
-# to configure the hosts/tenants/segments used in a simple setup.
-
-# Create hosts
-romana add-host ip-{{ stack_nodes.Controller.mgmt_ip | replace('.', '-') }} {{ stack_nodes.Controller.mgmt_ip }} {{ stack_nodes.Controller.gateway }} 9604
-{% for node in stack_nodes.ComputeNodes[:compute_nodes] %}
-romana add-host ip-{{ stack_nodes[node].mgmt_ip | replace('.', '-') }} {{ stack_nodes[node].mgmt_ip }} {{ stack_nodes[node].gateway }} 9604
-{% endfor %}
-
 # Create tenants and segments
 romana create-tenant admin
 romana add-segment admin default
@@ -53,9 +44,6 @@ fi
 if ! nova keypair-show shared-key 2>/dev/null; then
 	nova keypair-add --pub-key ~/.ssh/id_rsa.pub shared-key
 fi
-
-# Boot inst1 using romana's network
-# - nova boot --flavor m1.micro --image cirros-0.3.4-x86_64-uec --key-name shared-key --nic net-id=$(neutron net-show romana -Fid -f value) inst1
 
 # Add Nano and Micro Flavours if it is not present.
 if ! nova flavor-show m1.nano &>/dev/null; then

--- a/romana-install/roles/romana/kubernetes-postinstall/files/dashboard/kube-ui-rc.yaml
+++ b/romana-install/roles/romana/kubernetes-postinstall/files/dashboard/kube-ui-rc.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-ui-v4
+  namespace: kube-system
+  labels:
+    k8s-app: kube-ui
+    version: v4
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kube-ui
+    version: v4
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-ui
+        version: v4
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: kube-ui
+        image: gcr.io/google_containers/kube-ui:v4
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+      # Force this to be created on master node for now
+      nodeSelector:
+        apiserver: present

--- a/romana-install/roles/romana/kubernetes-postinstall/files/dashboard/kube-ui-svc.yaml
+++ b/romana-install/roles/romana/kubernetes-postinstall/files/dashboard/kube-ui-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-ui
+  namespace: kube-system
+  labels:
+    k8s-app: kube-ui
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeUI"
+spec:
+  selector:
+    k8s-app: kube-ui
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/romana-install/roles/romana/kubernetes-postinstall/files/dashboard/namespace-kube-system.yaml
+++ b/romana-install/roles/romana/kubernetes-postinstall/files/dashboard/namespace-kube-system.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kube-system
+  labels:
+    name: kube-system

--- a/romana-install/roles/romana/kubernetes-postinstall/tasks/main.yml
+++ b/romana-install/roles/romana/kubernetes-postinstall/tasks/main.yml
@@ -1,15 +1,30 @@
 ---
-- name: Create bin directory
-  file: path="/home/ubuntu/bin/" mode=0775 state=directory
-
-- name: Install romana tool
-  template: src="../cmd/romana.k8s" dest="/home/ubuntu/bin/romana" mode=0775
-
-- name: Install romana post-install script
-  template: src="romana-post-install.sh" dest="/var/tmp/romana-post-install.sh" mode=0755
+- name: Install kubernetes post-install script
+  template: src="kubernetes-post-install.sh" dest="/var/tmp/kubernetes-post-install.sh" mode=0755
         
-- name: Execute romana post-install script
-  shell: /var/tmp/romana-post-install.sh
+- name: Execute kubernetes post-install script
+  shell: /var/tmp/kubernetes-post-install.sh
+
+- name: Copy dashboard files
+  copy: src="dashboard/{{ item }}" dest="{{ kubernetes_x_dir }}/{{ item }}"
+  with_items:
+    - namespace-kube-system.yaml
+    - kube-ui-rc.yaml
+    - kube-ui-svc.yaml
+  register: kui
+
+# Workaround for lack of routes between node with apiserver and node running kube-ui pods
+# label here, nodeSelector using label in kube-ui-rc.yaml
+- name: Add a label to master node
+  command: kubectl label node "ip-{{ stack_nodes.Controller.mgmt_ip | replace('.', '-') }}" "apiserver=present"
+
+- name: Create resources
+  when: kui.changed
+  command: kubectl create -f "{{ kubernetes_x_dir }}/{{ item }}"
+  with_items:
+    - namespace-kube-system.yaml
+    - kube-ui-rc.yaml
+    - kube-ui-svc.yaml
 
 - name: Create demo directory
   file: path="/home/ubuntu/demo/" mode=0775 state=directory

--- a/romana-install/roles/romana/kubernetes-postinstall/templates/kubernetes-post-install.sh
+++ b/romana-install/roles/romana/kubernetes-postinstall/templates/kubernetes-post-install.sh
@@ -22,18 +22,11 @@ fi
 # Suppress output
 exec > /dev/null
 
-# This script currently directly uses the REST API of the Romana Topology and Tenant services
-# to configure the hosts/owners/tiers used in a simple setup.
-
-# Create hosts
-romana add-host ip-{{ stack_nodes.Controller.mgmt_ip | replace('.', '-') }} {{ stack_nodes.Controller.mgmt_ip }} {{ stack_nodes.Controller.gateway }} 9604
-{% for node in stack_nodes.ComputeNodes[:compute_nodes] %}
-romana add-host ip-{{ stack_nodes[node].mgmt_ip | replace('.', '-') }} {{ stack_nodes[node].mgmt_ip }} {{ stack_nodes[node].gateway }} 9604
-{% endfor %}
-
-# Create owners and tiers
+# Create tenants and segments
 romana create-tenant default
 romana add-segment default default
+romana create-tenant kube-system
+romana add-segment kube-system default
 romana create-tenant tenant-a
 romana add-segment tenant-a default
 romana add-segment tenant-a backend

--- a/romana-install/roles/romana/postinstall/tasks/main.yml
+++ b/romana-install/roles/romana/postinstall/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Ensure the jq tool is installed
+- apt: pkg="jq"
+  become: true
+  become_user: root
+
+- name: Create bin directory
+  file: path="/home/ubuntu/bin/" mode=0775 state=directory
+
+- name: Install romana tool
+  when: stack_type == "devstack"
+  template: src="../cmd/romana.ds" dest="/home/ubuntu/bin/romana" mode=0775
+
+- name: Install romana tool
+  when: stack_type == "kubernetes"
+  template: src="../cmd/romana.k8s" dest="/home/ubuntu/bin/romana" mode=0775
+
+- name: Install romana post-install script
+  template: src="romana-post-install.sh" dest="/var/tmp/romana-post-install.sh" mode=0755
+        
+- name: Execute romana post-install script
+  shell: /var/tmp/romana-post-install.sh

--- a/romana-install/roles/romana/postinstall/templates/romana-post-install.sh
+++ b/romana-install/roles/romana/postinstall/templates/romana-post-install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright (c) 2016 Pani Networks
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+if [[ -f $HOME/.profile ]]; then
+	source "$HOME/.profile"
+fi
+
+# Suppress output
+exec > /dev/null
+
+# Create hosts
+romana add-host ip-{{ stack_nodes.Controller.mgmt_ip | replace('.', '-') }} {{ stack_nodes.Controller.mgmt_ip }} {{ stack_nodes.Controller.gateway }} 9604
+{% for node in stack_nodes.ComputeNodes[:compute_nodes] %}
+romana add-host ip-{{ stack_nodes[node].mgmt_ip | replace('.', '-') }} {{ stack_nodes[node].mgmt_ip }} {{ stack_nodes[node].gateway }} 9604
+{% endfor %}

--- a/romana-install/roles/summary/templates/kubernetes_stackinfo
+++ b/romana-install/roles/summary/templates/kubernetes_stackinfo
@@ -5,6 +5,7 @@ Master
 ------
 {% for i in groups.controller %}{% set n = hostvars[i] %}
 IP: {{ n.ansible_ssh_host }}
+http://{{ n.ansible_ssh_host }}:8080/ui/
 ssh -i {{ "romana_id_rsa" | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
 {% endfor %}
 


### PR DESCRIPTION
This adds `kubernetes/kube-ui` to a demo install of kubernetes.
Apparently this UI is being dropped in favour of the new `kubernetes/dashboard`, so it might need updating.

Just want to note: because of the way agent currently sets up routes, if this service is created on an arbitrary node in the cluster, it's not reachable from any central point. I'm not sure the proper way to deal with that, so for now I've just forced it to create the pod on the master node.