### PR TITLE
installer updated for kubernetes 1.2.0

### DIFF
--- a/romana-install/group_vars/kube_nodes
+++ b/romana-install/group_vars/kube_nodes
@@ -1,5 +1,5 @@
-kubernetes_version: "1.1.8"
-kubernetes_sha1: "496e4e214804df9271c1065150a9e553b518dd42"
+kubernetes_version: "1.2.0"
+kubernetes_sha1: "52dd998e1191f464f581a9b87017d70ce0b058d9"
 kubernetes_url: "https://github.com/kubernetes/kubernetes/releases/download/v{{ kubernetes_version }}/kubernetes.tar.gz"
 
 kubernetes_dl_dir: "/var/tmp"

--- a/romana-install/roles/romana/kubernetes-postinstall/files/demo/romana-np-frontend-to-backend.json
+++ b/romana-install/roles/romana/kubernetes-postinstall/files/demo/romana-np-frontend-to-backend.json
@@ -2,7 +2,7 @@
    "metadata": {
      "name" : "pol1"
    },
-   "apiVersion" : "romana.io/demo/v1",
+   "groupVersion" : "romana.io/demo/v1",
    "kind" : "NetworkPolicy",
    "spec" : { 
                "podSelector" : { 

--- a/romana-install/roles/stack/kubernetes/install-minion/tasks/main.yml
+++ b/romana-install/roles/stack/kubernetes/install-minion/tasks/main.yml
@@ -3,10 +3,10 @@
   become: true
   become_user: root
 
-- include: services.yml
+- include: cni.yml
   become: true
   become_user: root
 
-- include: cni.yml
+- include: services.yml
   become: true
   become_user: root


### PR DESCRIPTION
kubernetes [1.2.0](https://github.com/kubernetes/kubernetes/releases/tag/v1.2.0) dropped today, requiring a retest and minor changes to make our basic setup and demo continue to work with 1.2.

This PR is to merge those onto the kube-namespaces branch for now, until we're ready to merge that one to master. (Could I get confirmation on the kube-namespaces PR also? It'd be good to close both.)