### PR TITLE
Static hosts

### DIFF
--- a/romana-install/create_hosts.static.yml
+++ b/romana-install/create_hosts.static.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Create a link to the inventory
+      file: path="{{ stack_data_dir }}/inventory" state=link src="{{ static_inventory }}"

--- a/romana-install/delete_hosts.static.yml
+++ b/romana-install/delete_hosts.static.yml
@@ -1,0 +1,2 @@
+# No action required
+- hosts: localhost

--- a/romana-install/pre-delete.yml
+++ b/romana-install/pre-delete.yml
@@ -2,6 +2,7 @@
 - hosts: localhost
   tasks:
     - name: Remove IPs from known_hosts
+      when: platform in [ "aws", "vagrant" ]
       known_hosts: host="{{ hostvars[item].ansible_ssh_host }}" state=absent
       with_items: "{{ groups.stack_nodes | default([]) }}"
       failed_when: false

--- a/romana-install/roles/summary/templates/devstack_stackinfo
+++ b/romana-install/roles/summary/templates/devstack_stackinfo
@@ -7,11 +7,11 @@ Controller
 IP: {{ n.ansible_ssh_host }}
 http://{{ n.ansible_ssh_host}}
 (username: admin, password: {{ stack_password }})
-ssh -i {{ "romana_id_rsa" | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
+ssh -i {{ n.ansible_ssh_private_key_file | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
 {% endfor %}
 
 Other Nodes
 -----------
 {% for i in groups.computes %}{% set n = hostvars[i] %}
-ssh -i {{ "romana_id_rsa" | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
+ssh -i {{ n.ansible_ssh_private_key_file | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
 {% endfor %}

--- a/romana-install/roles/summary/templates/kubernetes_stackinfo
+++ b/romana-install/roles/summary/templates/kubernetes_stackinfo
@@ -5,11 +5,11 @@ Master
 ------
 {% for i in groups.controller %}{% set n = hostvars[i] %}
 IP: {{ n.ansible_ssh_host }}
-ssh -i {{ "romana_id_rsa" | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
+ssh -i {{ n.ansible_ssh_private_key_file | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
 {% endfor %}
 
 Minions
 -------
 {% for i in groups.computes %}{% set n = hostvars[i] %}
-ssh -i {{ "romana_id_rsa" | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
+ssh -i {{ n.ansible_ssh_private_key_file | realpath }}{% if n.ansible_ssh_port | default(22) != 22 %} -p {{ n.ansible_ssh_port }}{% endif %} {{ n.ansible_ssh_user }}@{{ n.ansible_ssh_host }}
 {% endfor %}

--- a/romana-install/roles/system/tasks/main.yml
+++ b/romana-install/roles/system/tasks/main.yml
@@ -23,3 +23,4 @@
   when: ansible_service_mgr == "upstart"
 
 - include: ssh_keys.yml
+  when: platform in [ "aws", "vagrant" ]

--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -22,7 +22,7 @@ usage() {
 	echo "       romana-setup <h|--help>"
 	echo ""
 	echo "Stack Name:  user-defined stack name (default: $USER)"
-	echo "Platforms:   aws (default), vagrant"
+	echo "Platforms:   aws (default), vagrant, static"
 	echo "Distro:      ubuntu (default), centos"
 	echo "Stack Types: devstack (default), kubernetes"
 	echo "Actions:     install (default), uninstall"
@@ -49,8 +49,9 @@ fi
 stack_name="$USER"
 distro="ubuntu"
 platform="aws"
+inventory=""
 stack_type="devstack"
-required=( ansible-playbook )
+required=( ansible ansible-playbook )
 
 # Process command-line options
 if (( $# > 0 )); then 
@@ -61,16 +62,8 @@ if (( $# > 0 )); then
 				exit 0
 				;;
 			-n|--name)
-				case "$2" in
-					[a-zA-Z][a-zA-Z0-9]*)
-						stack_name="$2"
-						shift 2
-						;;
-					*)
-						echo "Invalid stack name: '$2' (must start with a letter, and contain only letters and digits)"
-						exit 1
-						;;
-				esac
+				stack_name="$2"
+				shift 2
 				;;
 			-d|--distro)
 				case "$2" in
@@ -84,6 +77,10 @@ if (( $# > 0 )); then
 						;;
 				esac
 				;;
+			-i|--inventory)
+				inventory="$2"
+				shift 2
+				;;
 			-p|--platform)
 				case "$2" in
 					aws)
@@ -94,6 +91,10 @@ if (( $# > 0 )); then
 					vagrant)
 						platform="vagrant"
 						required+=( "vagrant" )
+						shift 2
+						;;
+					static)
+						platform="static"
 						shift 2
 						;;
 					*)
@@ -156,6 +157,36 @@ for i in "${required[@]}"; do
 	fi
 done
 
+# Validate the options / combinations
+# stack name is valid:
+case "$stack_name" in
+	[a-zA-Z][a-zA-Z0-9]*)
+		# OK
+		;;
+	*)
+		echo "Invalid stack name: '$stack_name' (must start with a letter, and contain only letters and digits)"
+		exit 1
+		;;
+esac
+# static hosts, inventory must be set
+if [[ $platform = "static" ]]; then
+	if ! [[ "$inventory" ]]; then
+		echo "Inventory must be provided when using static infrastructure."
+		exit 1
+	fi
+	if ! [[ -e "$inventory" ]]; then
+		echo "Inventory '$inventory' not found."
+		exit 1
+	fi
+fi
+# inventory must not be set if using other platforms
+if [[ $platform != "static" ]]; then
+	if [[ "$inventory" ]]; then
+		echo "Inventory must not be provided when using non-static infrastructure."
+		exit 1
+	fi
+fi
+
 stack_data_dir="stacks/${stack_name}_${platform}_${distro}_${stack_type}"
 mkdir -p "${stack_data_dir}"
 
@@ -168,13 +199,17 @@ if [[ "$platform" == "aws" ]] && [[ -r ~/.aws/ec2_keypair ]]; then
 		ansible_args+=( -e ec2_keypair="$ec2_keypair" )
 	fi
 fi
+# Add static inventory setting if platform is static
+if [[ "$platform" == "static" ]]; then
+	ansible_args+=( -e static_inventory="$inventory" )
+fi
 
 case "$platform" in
-	aws|vagrant)
+	aws|vagrant|static)
 		case "$action" in
 			install)
 				ansible-playbook "$@" "${ansible_args[@]}" -i localhost create_hosts.yml  || exit 1
-				ansible-playbook "$@" "${ansible_args[@]}" -i "${stack_data_dir}/inventory" post-create.yml &&
+				ansible-playbook "$@" "${ansible_args[@]}" -i "${stack_data_dir}/inventory" post-create.yml
 				hosts_ready=0
 				for ((i=0; i < 5; i++)); do
 					echo "Attempting to connect to hosts"

--- a/static_hosts.md
+++ b/static_hosts.md
@@ -1,0 +1,61 @@
+# Installing Romana on static hosts
+
+The `romana-setup` tool allows you to provide a list of hosts that were provisioned manually or with other tools, and perform the installation on those hosts.
+
+This is done by providing an Ansible `inventory` file when running the `romana-setup` command.
+
+Each host needs to sastisfy the minimum requirements before the installtion can be performed.
+
+## Minimum Requirements
+
+- A Redhat- or Debian-based linux distribution installed
+- Access to the internet for downloading additional files
+- Access to other hosts via the same network segment
+- An unprivileged user with `sudo` access
+- `sudo` not requiring a password for that unprivileged user
+- `sudo` configured to not require a TTY 
+- Key-based SSH access for that unprivileged user
+- Python installed
+- Python packages for the distro package manager installed (eg: `python-apt`, `python-yum`)
+
+## Inventory file
+
+The inventory file provides the list of hosts to use for installation, the details required to connect to them, and the role of the host.
+
+```
+example-controller ansible_ssh_host="192.168.10.10" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="/home/example/example_id_rsa" stack_host="Controller"
+example-compute01  ansible_ssh_host="192.168.10.11" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="/home/example/example_id_rsa" stack_host="Compute01"
+# Additional compute hosts may be specified here, eg
+# example-compute02  ansible_ssh_host="192.168.10.02" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="/home/example/example_id_rsa" stack_host="Compute02"
+# example-compute03  ansible_ssh_host="192.168.10.03" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="/home/example/example_id_rsa" stack_host="Compute03"
+# example-compute04  ansible_ssh_host="192.168.10.04" ansible_ssh_user="ubuntu" ansible_ssh_private_key_file="/home/example/example_id_rsa" stack_host="Compute04"
+
+[stack_nodes:children]
+controller
+computes
+
+[controller]
+example-controller
+
+[computes]
+example-compute01
+# The names of additional compute hosts should be put here also, eg
+# example-compute02
+# example-compute03
+# example-compute04
+```
+
+## Installation
+
+Run the installation, specifying `-p static` and the path to the inventory file using `-i /path/to/inventory`.
+
+```bash
+cd romana-install
+./romana-setup -n example -p static -i /path/to/inventory -d ubuntu -s kubernetes install
+```
+
+
+## Uninstallation
+
+This should be performed manually, or using the provisioning tools used to create the hosts.
+Running the `uninstall` command cleans up local files created during installation but does no other action on the hosts.


### PR DESCRIPTION
Provides a way for users to install Romana using this setup tool, but on hosts they have provisioned themselves.
The user is expected to provide an Ansible inventory and ensure the host has been configured appropriately to the same level as our automatically provisioned hosts.
(Eg: SSH available, key-based authentication, sudo access without a password prompt.)
