### PR TITLE
Specifying interpreter allows installer to work in virtualenv

### DIFF
--- a/romana-install/localhost
+++ b/romana-install/localhost
@@ -1,2 +1,2 @@
 # Simple predefined inventory to suppress warnings when provisioning/terminating hosts
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter=python


### PR DESCRIPTION
This should be merged so the virtualenv users don't get tripped up by weird errors about missing modules.