### PR TITLE
Generate and use SSH key internally even for static hosts.

### DIFF
--- a/romana-install/create_hosts.static.yml
+++ b/romana-install/create_hosts.static.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: localhost
+  roles:
+    - provision/generate-ssh-key
   tasks:
     - name: Create a link to the inventory
       file: path="{{ stack_data_dir }}/inventory" state=link src="{{ static_inventory }}"

--- a/romana-install/roles/system/tasks/main.yml
+++ b/romana-install/roles/system/tasks/main.yml
@@ -23,4 +23,3 @@
   when: ansible_service_mgr == "upstart"
 
 - include: ssh_keys.yml
-  when: platform in [ "aws", "vagrant" ]

--- a/romana-install/roles/system/tasks/ssh_keys.yml
+++ b/romana-install/roles/system/tasks/ssh_keys.yml
@@ -1,9 +1,19 @@
 ---
+- name: Check for private key
+  stat: path="~/.ssh/id_rsa"
+  register: privkey
+
+- name: Check for public key
+  stat: path="~/.ssh/id_rsa"
+  register: pubkey
+
 - name: Install private key for user
   copy: src="{{ romana_ssh_key }}" dest="~/.ssh/id_rsa" mode=0600
+  when: not privkey.stat.exists and not pubkey.stat.exists
 
 - name: Install public key for user
   copy: src="{{ romana_ssh_key}}.pub" dest="~/.ssh/id_rsa.pub" mode=0644
+  when: not privkey.stat.exists and not pubkey.stat.exists
 
 - name: Add public key to authorised keys
   authorized_key: user="{{ ansible_ssh_user }}" key="{{ item }}" state=present


### PR DESCRIPTION
Opening this PR to discuss whether it's appropriate to do this for static hosts.

It's convenient if the user hasn't already configured a common SSH keypair on all hosts, and convenient for SSH-ing into openstack compute instances from the host, because this key gets added as a nova keypair.
But.. if a common keypair _was_ already installed (for this `ansible_ssh_user`) then it'll overwrite it.
Is that bad?
The workaround would be copying the desired keypair to `romana_id_rsa` and `romana_id_rsa.pub` before installing, or creating a different user on the hosts.