### PR TITLE
Build core from source

### DIFF
--- a/romana-install/group_vars/all/go
+++ b/romana-install/group_vars/all/go
@@ -1,0 +1,4 @@
+# Go version to download and install
+go_version: "1.6.2"
+go_sha1:    "b8318b09de06076d5397e6ec18ebef3b45cd315d"
+go_url:     "https://storage.googleapis.com/golang/go{{ go_version }}.linux-amd64.tar.gz"

--- a/romana-install/group_vars/all/romana
+++ b/romana-install/group_vars/all/romana
@@ -3,6 +3,10 @@ romana_core_branch: "v0.8.1"
 romana_kube_branch: "v0.8.1"
 romana_networking_branch: "v0.8.1-stable/liberty"
 
+# Install from Github or S3 bucket
+romana_core_source: "s3"
+romana_core_repo:   "https://github.com/romana/core"
+
 # Paths
 romana_bin_dir: "/usr/local/bin"
 romana_lib_dir: "/usr/local/lib"

--- a/romana-install/roles/romana/install-agent/tasks/main.yml
+++ b/romana-install/roles/romana/install-agent/tasks/main.yml
@@ -3,9 +3,7 @@
   become: true
   become_user: root
 
-- include: romana_files.yml
-  become: true
-  become_user: root
+- include: "romana_from_{{ romana_core_source }}.yml"
 
 - include: "{{ item }}"
   with_first_found:

--- a/romana-install/roles/romana/install-agent/tasks/romana_from_github.yml
+++ b/romana-install/roles/romana/install-agent/tasks/romana_from_github.yml
@@ -1,0 +1,11 @@
+- name: Copy files built on master
+  command: rsync -az "{{ romana_master_ip }}:/var/tmp/gopath/bin/{{ item }}" "/var/tmp/{{ item }}"
+  with_items:
+    - agent
+
+- name: Install files
+  become: true
+  become_user: root
+  command: install -o root -g root -m 0755 "/var/tmp/{{ item }}" "{{ romana_bin_dir }}/{{ item }}"
+  with_items:
+    - agent

--- a/romana-install/roles/romana/install-agent/tasks/romana_from_s3.yml
+++ b/romana-install/roles/romana/install-agent/tasks/romana_from_s3.yml
@@ -1,10 +1,14 @@
 ---
 - name: Remove if binaries exist
+  become: true
+  become_user: root
   file: path="{{ romana_bin_dir }}/{{ item }}" state=absent
   with_items:
     - agent
 
 - name: Download latest binaries
+  become: true
+  become_user: root
   get_url: url="https://s3-us-west-1.amazonaws.com/romana-binaries/core/latest/origin/{{ romana_core_branch }}/{{ item }}" dest="{{ romana_bin_dir }}/{{ item }}" mode=0755
   with_items:
     - agent

--- a/romana-install/roles/romana/install-master/files/build_romana_core
+++ b/romana-install/roles/romana/install-master/files/build_romana_core
@@ -1,0 +1,11 @@
+#!/bin/bash
+export GOPATH=/var/tmp/gopath
+export PATH=/usr/local/go/bin:$PATH
+
+go get -d github.com/romana/core/...
+
+while IFS= read -r p; do
+	pkgs+=("$p")
+done < <(go list -f '{{ if eq .Name "main" }}{{ .ImportPath }}{{ end }}'  github.com/romana/core/... | grep -v /vendor/)
+
+GOBIN=/usr/local/bin go install "${pkgs[@]}"

--- a/romana-install/roles/romana/install-master/files/build_romana_core
+++ b/romana-install/roles/romana/install-master/files/build_romana_core
@@ -8,4 +8,4 @@ while IFS= read -r p; do
 	pkgs+=("$p")
 done < <(go list -f '{{ if eq .Name "main" }}{{ .ImportPath }}{{ end }}'  github.com/romana/core/... | grep -v /vendor/)
 
-GOBIN=/usr/local/bin go install "${pkgs[@]}"
+go install "${pkgs[@]}"

--- a/romana-install/roles/romana/install-master/tasks/main.yml
+++ b/romana-install/roles/romana/install-master/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
+- name: Prep stage before installing Romana binaries
+  become: true
+  become_user: root
+  include: "romana_prep.yml"
+
 - name: Install core romana applications for master node
   become: true
   become_user: root
-  include: romana_files.yml
+  include: "romana_from_{{ romana_core_source }}.yml"
 
 - name: Install configurations for romana root service
   become: true

--- a/romana-install/roles/romana/install-master/tasks/main.yml
+++ b/romana-install/roles/romana/install-master/tasks/main.yml
@@ -5,8 +5,6 @@
   include: "romana_prep.yml"
 
 - name: Install core romana applications for master node
-  become: true
-  become_user: root
   include: "romana_from_{{ romana_core_source }}.yml"
 
 - name: Install configurations for romana root service

--- a/romana-install/roles/romana/install-master/tasks/romana_from_github.yml
+++ b/romana-install/roles/romana/install-master/tasks/romana_from_github.yml
@@ -3,9 +3,9 @@
   register: dl
 
 - name: Install Go
-  unarchive: copy=no src="/var/tmp/go{{ go_version }}.tar.gz" dest="/usr/local"
   become: true
   become_user: root
+  unarchive: copy=no src="/var/tmp/go{{ go_version }}.tar.gz" dest="/usr/local"
   when: dl.changed
 
 - name: Create GOPATH directory
@@ -19,3 +19,13 @@
 
 - name: Run the build script
   shell: /var/tmp/build_romana_core
+
+- name: Install files
+  become: true
+  become_user: root
+  command: install -o root -g root -m 0755 "/var/tmp/gopath/bin/{{ item }}" "{{ romana_bin_dir }}/{{ item }}"
+  with_items:
+    - ipam
+    - root
+    - tenant
+    - topology

--- a/romana-install/roles/romana/install-master/tasks/romana_from_github.yml
+++ b/romana-install/roles/romana/install-master/tasks/romana_from_github.yml
@@ -1,0 +1,21 @@
+- name: Download Go
+  get_url: url="{{ go_url }}" checksum="sha1:{{ go_sha1 }}" dest="/var/tmp/go{{ go_version }}.tar.gz"
+  register: dl
+
+- name: Install Go
+  unarchive: copy=no src="/var/tmp/go{{ go_version }}.tar.gz" dest="/usr/local"
+  become: true
+  become_user: root
+  when: dl.changed
+
+- name: Create GOPATH directory
+  file: path="/var/tmp/gopath" mode=0775 state=directory
+
+- name: Clone romana core repo into GOPATH
+  git: repo="{{ romana_core_repo }}" version="{{ romana_core_branch }}" dest="/var/tmp/gopath/src/github.com/romana/core"
+
+- name: Copy a build script
+  copy: src="build_romana_core" dest="/var/tmp/build_romana_core" mode=0755
+
+- name: Run the build script
+  shell: /var/tmp/build_romana_core

--- a/romana-install/roles/romana/install-master/tasks/romana_from_s3.yml
+++ b/romana-install/roles/romana/install-master/tasks/romana_from_s3.yml
@@ -1,11 +1,4 @@
 ---
-- name: Ensure install path exists
-  file: path="{{ item }}" state=directory
-  with_items:
-    - "{{ romana_bin_dir }}"
-    - "{{ romana_lib_dir }}"
-    - "{{ romana_etc_dir }}"
-
 - name: Remove existing binaries
   file: path="{{ romana_bin_dir }}/{{ item }}" state=absent
   with_items:
@@ -21,6 +14,3 @@
     - root
     - tenant
     - topology
- 
-- name: Install config file
-  template: src="config/romana.conf.yml" dest="{{ romana_etc_dir }}/romana.conf.yml" mode=0644

--- a/romana-install/roles/romana/install-master/tasks/romana_from_s3.yml
+++ b/romana-install/roles/romana/install-master/tasks/romana_from_s3.yml
@@ -1,5 +1,7 @@
 ---
 - name: Remove existing binaries
+  become: true
+  become_user: root
   file: path="{{ romana_bin_dir }}/{{ item }}" state=absent
   with_items:
     - ipam
@@ -8,6 +10,8 @@
     - topology
 
 - name: Download latest binaries
+  become: true
+  become_user: root
   get_url: url="https://s3-us-west-1.amazonaws.com/romana-binaries/core/latest/origin/{{ romana_core_branch }}/{{ item }}" dest="{{ romana_bin_dir }}/{{ item }}" mode=0755
   with_items:
     - ipam

--- a/romana-install/roles/romana/install-master/tasks/romana_prep.yml
+++ b/romana-install/roles/romana/install-master/tasks/romana_prep.yml
@@ -1,0 +1,10 @@
+---
+- name: Ensure install path exists
+  file: path="{{ item }}" state=directory
+  with_items:
+    - "{{ romana_bin_dir }}"
+    - "{{ romana_lib_dir }}"
+    - "{{ romana_etc_dir }}"
+
+- name: Install config file
+  template: src="config/romana.conf.yml" dest="{{ romana_etc_dir }}/romana.conf.yml" mode=0644

--- a/romana-install/roles/system/tasks/packages_debian.yml
+++ b/romana-install/roles/system/tasks/packages_debian.yml
@@ -7,3 +7,4 @@
   with_items:
     - git
     - vim
+    - gcc

--- a/romana-install/roles/system/tasks/packages_redhat.yml
+++ b/romana-install/roles/system/tasks/packages_redhat.yml
@@ -9,3 +9,4 @@
   with_items:
     - git
     - vim-enhanced
+    - gcc

--- a/romana-install/roles/system/tasks/ssh_keys.yml
+++ b/romana-install/roles/system/tasks/ssh_keys.yml
@@ -9,3 +9,11 @@
   authorized_key: user="{{ ansible_ssh_user }}" key="{{ item }}" state=present
   with_file:
     - "{{ romana_ssh_key }}.pub"
+
+- name: Check for known_hosts
+  stat: path="~/.ssh/known_hosts"
+  register: kh
+
+- name: Add known_hosts
+  template: src="known_hosts" dest="~/.ssh/known_hosts" mode=0644
+  when: not kh.stat.exists

--- a/romana-install/roles/system/templates/known_hosts
+++ b/romana-install/roles/system/templates/known_hosts
@@ -1,0 +1,3 @@
+{% for n in groups.stack_nodes %}
+{{ hostvars[n].lan_ip }} ecdsa-sha2-nistp256 {{ hostvars[n].ansible_ssh_host_key_ecdsa_public }}
+{% endfor %}


### PR DESCRIPTION
Allows spinning up a cluster that builds the Core apps from github instead of downloading from S3.

Need to append `-e romana_core_source=github` at the end of the romana-setup install command.
Eg: `./romana-setup -n bfs -s kubernetes install -e romana_core_source=github`
(It may later become a direct option of `romana-setup`.)

One bonus feature: since we needed copying files via rsync (ssh) without a password prompt, the setup now generates a `known_hosts` file and puts that on each cluster host. No more `Are you sure you want to continue connecting (yes/no)?` prompts.
