### PR TITLE
Allow number of compute nodes as romana-setup option.

### DIFF
--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -25,7 +25,7 @@ usage() {
 	echo "Platforms:     aws (default), vagrant, static"
 	echo "Distro:        ubuntu (default), centos"
 	echo "Stack Types:   devstack (default), kubernetes"
-	echo "Number:        number of compute nodes"
+	echo "Number:        number of cluster nodes"
 	echo "Actions:       install (default), uninstall"
 	echo ""
 	echo "Example 1: Romana with Kubernetes on AWS"

--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -17,14 +17,15 @@
 
 usage() {
 	echo "romana-setup: executes the ansible playbooks for installing romana"
-	echo "Usage: romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] [action]"
-	echo "       romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] <action> [ansible-options]"
+	echo "Usage: romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] [-c number] [action]"
+	echo "       romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] [-c number] <action> [ansible-options]"
 	echo "       romana-setup <h|--help>"
 	echo ""
 	echo "Cluster Name:  user-defined stack name (default: $USER)"
 	echo "Platforms:     aws (default), vagrant, static"
 	echo "Distro:        ubuntu (default), centos"
 	echo "Stack Types:   devstack (default), kubernetes"
+	echo "Number:        number of compute nodes"
 	echo "Actions:       install (default), uninstall"
 	echo ""
 	echo "Example 1: Romana with Kubernetes on AWS"
@@ -51,6 +52,7 @@ distro="ubuntu"
 platform="aws"
 inventory=""
 stack_type="devstack"
+compute_nodes=""
 required=( ansible ansible-playbook )
 
 # Process command-line options
@@ -125,6 +127,10 @@ if (( $# > 0 )); then
 						;;
 				esac
 				;;
+			-c|--compute-nodes)
+				compute_nodes="$2"
+				shift 2
+				;;
 			*)
 				echo "Unrecognized option '$1'"
 				usage
@@ -186,6 +192,16 @@ if [[ $platform != "static" ]]; then
 		exit 1
 	fi
 fi
+# number of compute nodes. make sure it's a number, and within some limits
+if [[ "$compute_nodes" ]]; then case "$compute_nodes" in
+	# Between 0 and 199
+	0|[1-9]|[1-9][0-9]|1[0-9][0-9])
+		;;
+	*)
+		echo "Invalid number of compute nodes 'compute_nodes'. Value should be a number between 0 and 199."
+		exit 1
+		;;
+esac; fi
 
 stack_data_dir="stacks/${stack_name}_${platform}_${distro}_${stack_type}"
 mkdir -p "${stack_data_dir}"
@@ -202,6 +218,11 @@ fi
 # Add static inventory setting if platform is static
 if [[ "$platform" == "static" ]]; then
 	ansible_args+=( -e static_inventory="$inventory" )
+fi
+
+# Add number of compute nodes. Needs JSON format so Ansible treats it as an integer
+if [[ "$compute_nodes" ]]; then
+	ansible_args+=( -e '{ "compute_nodes": '"$compute_nodes"'}')
 fi
 
 case "$platform" in

--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -195,7 +195,7 @@ fi
 # number of cluster nodes. make sure it's a number, and within some limits
 if [[ "$cluster_nodes" ]]; then case "$cluster_nodes" in
 	# Between 0 and 200
-	1-9]|[1-9][0-9]|1[0-9][0-9]|200)
+	[1-9]|[1-9][0-9]|1[0-9][0-9]|200)
 		;;
 	*)
 		echo "Invalid number of cluster nodes '$cluster_nodes'. Value should be a number between 1 and 200."

--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -52,7 +52,7 @@ distro="ubuntu"
 platform="aws"
 inventory=""
 stack_type="devstack"
-compute_nodes=""
+cluster_nodes=""
 required=( ansible ansible-playbook )
 
 # Process command-line options
@@ -127,8 +127,8 @@ if (( $# > 0 )); then
 						;;
 				esac
 				;;
-			-c|--compute-nodes)
-				compute_nodes="$2"
+			-c|--cluster-nodes)
+				cluster_nodes="$2"
 				shift 2
 				;;
 			*)
@@ -192,13 +192,13 @@ if [[ $platform != "static" ]]; then
 		exit 1
 	fi
 fi
-# number of compute nodes. make sure it's a number, and within some limits
-if [[ "$compute_nodes" ]]; then case "$compute_nodes" in
-	# Between 0 and 199
-	0|[1-9]|[1-9][0-9]|1[0-9][0-9])
+# number of cluster nodes. make sure it's a number, and within some limits
+if [[ "$cluster_nodes" ]]; then case "$cluster_nodes" in
+	# Between 0 and 200
+	1-9]|[1-9][0-9]|1[0-9][0-9]|200)
 		;;
 	*)
-		echo "Invalid number of compute nodes 'compute_nodes'. Value should be a number between 0 and 199."
+		echo "Invalid number of cluster nodes '$cluster_nodes'. Value should be a number between 1 and 200."
 		exit 1
 		;;
 esac; fi
@@ -220,9 +220,10 @@ if [[ "$platform" == "static" ]]; then
 	ansible_args+=( -e static_inventory="$inventory" )
 fi
 
-# Add number of compute nodes. Needs JSON format so Ansible treats it as an integer
-if [[ "$compute_nodes" ]]; then
-	ansible_args+=( -e '{ "compute_nodes": '"$compute_nodes"'}')
+# Add number of compute nodes. One fewer than number of cluster nodes.
+# Needs JSON format so Ansible treats it as an integer
+if [[ "$cluster_nodes" ]]; then
+	ansible_args+=( -e '{ "compute_nodes": '"$((cluster_nodes - 1))"'}')
 fi
 
 case "$platform" in

--- a/romana_setup.md
+++ b/romana_setup.md
@@ -66,11 +66,11 @@ Valid values are:
 - `devstack` -- [OpenStack](http://www.openstack.org/) stable/liberty installed using [devstack](https://github.com/openstack-dev/devstack)
 - `kubernetes` -- [Kubernetes](http://kubernetes.io/) v1.2
 
-### Number of compute nodes
+### Number of cluster nodes
 
-The number of compute nodes to provision. This is used when creating the installation environment (`aws` and `vagrant` only), to override the quantity of compute nodes created.
+The number of cluster nodes to provision. This is used when creating the installation environment (`aws` and `vagrant` only), to override the quantity of cluster nodes created.
 
-Valid values are: a number between 0 and 199.
+Valid values are: a number between 1 and 200.
 
 ## Action Details
 

--- a/romana_setup.md
+++ b/romana_setup.md
@@ -8,14 +8,15 @@ This can be used to set up small clusters running Romana on AWS, Vagrant or pred
 
 ```
 romana-setup: executes the ansible playbooks for installing romana
-Usage: romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] [action]
-       romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] <action> [ansible-options]
+Usage: romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] [-c number] [action]
+       romana-setup [-n name] [-p platform] [-d distro] [-s stacktype] [-c number] <action> [ansible-options]
        romana-setup <h|--help>
 
 Cluster Name:  user-defined stack name (default: $USER)
 Platforms:     aws (default), vagrant, static
 Distro:        ubuntu (default), centos
 Stack Types:   devstack (default), kubernetes
+Number:        number of compute nodes
 Actions:       install (default), uninstall
 ```
 
@@ -64,6 +65,12 @@ This is installed and configured by `romana-setup` to use Romana components. Aft
 Valid values are:
 - `devstack` -- [OpenStack](http://www.openstack.org/) stable/liberty installed using [devstack](https://github.com/openstack-dev/devstack)
 - `kubernetes` -- [Kubernetes](http://kubernetes.io/) v1.2
+
+### Number of compute nodes
+
+The number of compute nodes to provision. This is used when creating the installation environment (`aws` and `vagrant` only), to override the quantity of compute nodes created.
+
+Valid values are: a number between 0 and 199.
 
 ## Action Details
 

--- a/romana_setup.md
+++ b/romana_setup.md
@@ -16,7 +16,7 @@ Cluster Name:  user-defined stack name (default: $USER)
 Platforms:     aws (default), vagrant, static
 Distro:        ubuntu (default), centos
 Stack Types:   devstack (default), kubernetes
-Number:        number of compute nodes
+Number:        number of cluster nodes
 Actions:       install (default), uninstall
 ```
 


### PR DESCRIPTION
This makes it easier to create clusters with a larger number of compute nodes.
It's already possible by specifying the correct, exact `-e` option in the parameters passed to Ansible. This is just to make it easier, with a `-c number` option.

Arbitrarily limited to 199, only tested to 10.