### PR TITLE
Refresh pip cache, reducing delay in install time for devstack

### DIFF
--- a/romana-install/group_vars/devstack_nodes
+++ b/romana-install/group_vars/devstack_nodes
@@ -1,3 +1,3 @@
 devstack_password: "{{ stack_password }}"
 devstack_service_token: "eb24cc1eb0036c7971237850c767d9f6bae017a3"
-devstack_pip_cache: "root_pip_cache_stable-liberty_20160403_{{ ansible_distribution|lower }}.tar.gz"
+devstack_pip_cache: "root_pip_cache_stable-liberty_20160531_{{ ansible_distribution|lower }}.tar.gz"


### PR DESCRIPTION
Updated cache pushed to S3.
This bumps the revision/filename the installer is configured to use.