### PR TITLE
Fix test steps to avoid errors. Update service names used in 0.9

### DIFF
--- a/romana-install/tests.kubernetes.yml
+++ b/romana-install/tests.kubernetes.yml
@@ -10,8 +10,6 @@
   tasks:
     - name: Copy test scripts to all kube nodes
       synchronize: src="../test/kubernetes-cluster/" dest="{{ test_dir }}/"
-    - name: Delete log file if present
-      file: path="{{ test_logfile }}" state=absent
 
 - hosts: kube_master
   tasks:

--- a/romana-install/tests.yml
+++ b/romana-install/tests.yml
@@ -17,6 +17,10 @@
       file: path="{{ test_dir }}" state=directory
     - name: Copy test script
       synchronize: src="../test/clustertests" dest="{{ test_script }}"
+    - name: Delete log file if present
+      file: path="{{ test_logfile }}" state=absent
+    - name: Create empty log file
+      file: path="{{ test_logfile }}" state=touch
        
 # Include stack-specific tests, copied then executed
 - include: "tests.{{ stack_type }}.yml"

--- a/test/kubernetes-cluster/tests
+++ b/test/kubernetes-cluster/tests
@@ -1,20 +1,20 @@
 command: services_running
-args: kube-apiserver kube-controller-manager kube-scheduler romana-kube-np
+args: kube-apiserver kube-controller-manager kube-scheduler romana-kube-listener
 description: Check that Kubernetes services are running on master
 labels: kube-master, services
 
 command: services_running
-args: romana-root romana-tenant romana-topology romana-ipam
+args: romana-root romana-tenant romana-topology romana-ipam romana-policy
 description: Check that Romana services are running on master
 labels: romana-master, services
 
 command: services_running
-args: kubelet kube-proxy romana-kube-agent
+args: kubelet kube-proxy
 description: Check that Kubernetes services are running on minion
 labels: kube-minion, services
 
 command: services_running
-args: romana-agent
+args: romana-agent romana-policy-agent
 description: Check that Romana services are running on minion
 labels: romana-agent, services
 


### PR DESCRIPTION
Update the tests to check for the correct services on 0.9.x (new or renamed.
Small fix in how test logs are handled, affecting all cluster types.