### PR TITLE
Allow custom repos when installing Romana from source

### DIFF
--- a/romana-install/group_vars/all/romana
+++ b/romana-install/group_vars/all/romana
@@ -5,7 +5,10 @@ romana_networking_branch: "v0.9.0-stable/liberty"
 
 # Install from Github or S3 bucket
 romana_core_source: "s3"
-romana_core_repo:   "https://github.com/romana/core"
+romana_repo_path:   "https://github.com/romana"
+romana_core_repo:   "{{ romana_repo_path }}/core"
+romana_kube_repo:   "{{ romana_repo_path }}/kube"
+romana_networking_repo:    "{{ romana_repo_path }}/networking-romana"
 
 # Paths
 romana_bin_dir: "/usr/local/bin"

--- a/romana-install/group_vars/all/stack
+++ b/romana-install/group_vars/all/stack
@@ -1,5 +1,6 @@
 stack_password: "secrete"
 romana_ssh_key: "romana_id_rsa"
+git_ssh_options: "-o StrictHostKeyChecking=no"
 compute_nodes: 1
 
 romana_master_ip: "{{ hostvars[groups.controller[0]].lan_ip }}"

--- a/romana-install/roles/romana/install-agent/tasks/policy_agent.yml
+++ b/romana-install/roles/romana/install-agent/tasks/policy_agent.yml
@@ -1,27 +1,13 @@
 ---
-- name: Copy policy-agent from master
-  get_url: url=https://raw.githubusercontent.com/romana/core/{{ romana_core_branch }}/pkg/util/policy/agent/agent.py dest=/var/tmp/agent.py mode=0755
-
-- name: Install files
-  become: true
-  become_user: root
-  command: install -o root -g root -m 0755 "/var/tmp/{{ item }}" "{{ romana_bin_dir }}/{{ item }}"
-  with_items:
-    - agent.py
-
 - name: Install Agent Proxy Add Policy
   become: true
   become_user: root
   copy: src="agent_proxy_add_policy.sh" dest="{{ romana_bin_dir }}/" mode=0755
-  with_items:
-    - agent
 
 - name: Install Agent Proxy Delete Policy
   become: true
   become_user: root
   copy: src="agent_proxy_delete_policy.sh" dest="{{ romana_bin_dir }}/" mode=0755
-  with_items:
-    - agent
 
 - name: Install romana command line config file
   template: src="config/romana.yaml" dest="/home/{{ ansible_ssh_user }}/.romana.yaml" mode=0644

--- a/romana-install/roles/romana/install-agent/tasks/romana_from_github.yml
+++ b/romana-install/roles/romana/install-agent/tasks/romana_from_github.yml
@@ -4,6 +4,9 @@
     - agent
     - romana
 
+- name: Copy policy agent from master
+  command: rsync -az "{{ romana_master_ip }}:/var/tmp/gopath/src/github.com/romana/core/pkg/util/policy/agent/agent.py" "/var/tmp/agent.py"
+
 - name: Install files
   become: true
   become_user: root
@@ -11,3 +14,4 @@
   with_items:
     - agent
     - romana
+    - agent.py

--- a/romana-install/roles/romana/install-agent/tasks/romana_from_s3.yml
+++ b/romana-install/roles/romana/install-agent/tasks/romana_from_s3.yml
@@ -15,5 +15,10 @@
     - agent
     - romana
 
+- name: Copy policy-agent from github
+  become: true
+  become_user: root
+  get_url: url=https://raw.githubusercontent.com/romana/core/{{ romana_core_branch }}/pkg/util/policy/agent/agent.py dest=/var/tmp/agent.py mode=0755
+
 - name: Install romana command line config file
   template: src="config/romana.yaml" dest="/home/{{ ansible_ssh_user }}/.romana.yaml" mode=0644

--- a/romana-install/roles/romana/install-master/tasks/romana_from_github.yml
+++ b/romana-install/roles/romana/install-master/tasks/romana_from_github.yml
@@ -12,7 +12,7 @@
   file: path="/var/tmp/gopath" mode=0775 state=directory
 
 - name: Clone romana core repo into GOPATH
-  git: repo="{{ romana_core_repo }}" version="{{ romana_core_branch }}" dest="/var/tmp/gopath/src/github.com/romana/core"
+  git: repo="{{ romana_core_repo }}" version="{{ romana_core_branch }}" dest="/var/tmp/gopath/src/github.com/romana/core" key_file={{ github_key|default(omit) }} ssh_opts={{ git_ssh_options }}
 
 - name: Copy a build script
   copy: src="build_romana_core" dest="/var/tmp/build_romana_core" mode=0755

--- a/romana-install/roles/stack/devstack/install-controller/tasks/main.yml
+++ b/romana-install/roles/stack/devstack/install-controller/tasks/main.yml
@@ -3,6 +3,9 @@
   become: true
   become_user: root
 
+- name: Clone networking-romana repo
+  git: repo="{{ romana_networking_repo }}" version="{{ romana_networking_branch }}" dest="/var/tmp/networking-romana" key_file={{ github_key|default(omit) }} ssh_opts={{ git_ssh_options }} ssh_opts={{ git_ssh_options }}
+
 - name: Install controller local.conf
   template: src="local.conf" dest="~/devstack/local.conf"
 

--- a/romana-install/roles/stack/devstack/install-controller/templates/local.conf
+++ b/romana-install/roles/stack/devstack/install-controller/templates/local.conf
@@ -13,7 +13,7 @@ enable_service q-meta
 enable_service neutron
 
 enable_service romana
-enable_plugin networking-romana https://github.com/romana/networking-romana{% if romana_networking_branch is defined %} {{ romana_networking_branch }}
+enable_plugin networking-romana /var/tmp/networking-romana{% if romana_networking_branch is defined %} {{ romana_networking_branch }}
 {% endif %}
 Q_PLUGIN=ml2
 Q_ML2_PLUGIN_MECHANISM_DRIVERS=romana

--- a/romana-install/roles/stack/kubernetes/prep/tasks/romana_kube.yml
+++ b/romana-install/roles/stack/kubernetes/prep/tasks/romana_kube.yml
@@ -1,3 +1,3 @@
 ---
 - name: Get the romana/kube repository
-  git: repo="https://github.com/romana/kube" version="{{ romana_kube_branch }}" dest="{{ kubernetes_x_dir}}/kube"
+  git: repo="{{ romana_kube_repo }}" version="{{ romana_kube_branch }}" dest="{{ kubernetes_x_dir}}/kube" key_file={{ github_key|default(omit) }} ssh_opts={{ git_ssh_options }}

--- a/romana-install/roles/system/tasks/ssh_keys.yml
+++ b/romana-install/roles/system/tasks/ssh_keys.yml
@@ -27,3 +27,7 @@
 - name: Add known_hosts
   template: src="known_hosts" dest="~/.ssh/known_hosts" mode=0644
   when: not kh.stat.exists
+
+- name: Copy github key
+  copy: src="{{ github_key }}" dest="~/.ssh/" mode=0600
+  when: github_key is defined

--- a/romana-install/romana-setup
+++ b/romana-install/romana-setup
@@ -57,6 +57,14 @@ stack_type="devstack"
 cluster_nodes=""
 required=( ansible ansible-playbook )
 
+core_source=
+core_branch=
+networking_branch=
+kube_branch=
+github_key=
+github_user=
+github_repo=
+
 # Process command-line options
 if (( $# > 0 )); then 
 	while [[ $1 == -* ]]; do
@@ -131,6 +139,35 @@ if (( $# > 0 )); then
 				;;
 			-c|--cluster-nodes)
 				cluster_nodes="$2"
+				shift 2
+				;;
+# Options for core developers. Not for general users, so excluded from usage/documentation
+			--source)
+				core_source="github"
+				shift
+				;;
+			--core-branch)
+				core_branch="$2"
+				shift 2
+				;;
+			--networking-branch)
+				networking_branch="$2"
+				shift 2
+				;;
+			--kube-branch)
+				kube_branch="$2"
+				shift 2
+				;;
+			--github-key)
+				github_key="$2"
+				shift 2
+				;;
+			--github-user)
+				github_user="$2"
+				shift 2
+				;;
+			--github-repo)
+				github_repo="$2"
 				shift 2
 				;;
 			*)
@@ -226,6 +263,31 @@ fi
 # Needs JSON format so Ansible treats it as an integer
 if [[ "$cluster_nodes" ]]; then
 	ansible_args+=( -e '{ "compute_nodes": '"$((cluster_nodes - 1))"'}')
+fi
+
+# Change install source
+if [[ "$core_source" ]]; then
+	ansible_args+=( -e romana_core_source="$core_source" )
+fi
+# Change source repo url
+if [[ "$github_repo" ]]; then
+	ansible_args+=( -e romana_repo_path="$core_source" )
+elif [[ "$github_user" ]]; then
+	ansible_args+=( -e romana_repo_path="git@github.com:$github_user" )
+fi
+# Change branches to pull
+if [[ "$core_branch" ]]; then
+	ansible_args+=( -e romana_core_branch="$core_branch" )
+fi
+if [[ "$networking_branch" ]]; then
+	ansible_args+=( -e romana_networking_branch="$networking_branch" )
+fi
+if [[ "$kube_branch" ]]; then
+	ansible_args+=( -e romana_kube_branch="$kube_branch" )
+fi
+# Change github key
+if [[ "$github_key" ]]; then
+	ansible_args+=( -e github_key="$github_key" )
 fi
 
 case "$platform" in


### PR DESCRIPTION
Additional installer options for creating clusters using custom repos and branches.
The options are very dev-team oriented, so they are not currently part of the usage documentation.

New options:
--source: Build romana from source.
--github-repo: Full path to the github location for repos. `https://github.com/username` or `git@github.com:username` format
--github-user: A shorter way of describing the `git@github.com:username` path.
--github-key: The path to the SSH key required to access the repository
--core-branch: Name of branch/tag/commit to pull for `core`
--networking-branch: Name of branch/tag/commit to pull for `networking-romana`
--kube-branch: Name of branch/tag/commit to pull for `kube`

Example usage:
`./romana-setup -n kube123 -s kubernetes --source --github-user aprivateorg --github-key ~/.ssh/orgname_id_rsa --kube-branch master install`