### PR TITLE
Install jq at system-prep stage on all nodes.

### DIFF
--- a/romana-install/roles/stack/kubernetes/install-minion/tasks/packages_debian.yml
+++ b/romana-install/roles/stack/kubernetes/install-minion/tasks/packages_debian.yml
@@ -18,4 +18,3 @@
     - docker-engine
     - python-simplejson
     - python-requests
-    - jq

--- a/romana-install/roles/stack/kubernetes/install-minion/tasks/packages_redhat.yml
+++ b/romana-install/roles/stack/kubernetes/install-minion/tasks/packages_redhat.yml
@@ -8,4 +8,3 @@
     - docker-engine
     - python-simplejson
     - python-requests
-    - jq

--- a/romana-install/roles/stack/openstack/prep/tasks/packages_redhat.yml
+++ b/romana-install/roles/stack/openstack/prep/tasks/packages_redhat.yml
@@ -4,7 +4,6 @@
   with_items:
     - python-pip
     - patch
-    - jq
 
 - name: Install centos-openstack-release packages
   yum: pkg="centos-release-openstack-liberty" update_cache=yes

--- a/romana-install/roles/stack/openstack/prep/tasks/packages_ubuntu.yml
+++ b/romana-install/roles/stack/openstack/prep/tasks/packages_ubuntu.yml
@@ -15,4 +15,3 @@
   apt: pkg="{{ item }}"
   with_items:
     - python-pip
-    - jq

--- a/romana-install/roles/system/tasks/packages_debian.yml
+++ b/romana-install/roles/system/tasks/packages_debian.yml
@@ -28,4 +28,5 @@
   with_items:
     - git
     - vim
+    - jq
     - gcc

--- a/romana-install/roles/system/tasks/packages_redhat.yml
+++ b/romana-install/roles/system/tasks/packages_redhat.yml
@@ -13,4 +13,5 @@
   with_items:
     - git
     - vim-enhanced
+    - jq
     - gcc


### PR DESCRIPTION
Because it's useful -- for functionality, for operations, for tests that interact with json, etc.
Seems sensible to do it here than selectively in multiple places.