### PR TITLE
Fix vagrant hostnames

### DIFF
--- a/romana-install/roles/provision/create-vagrant-hosts/templates/Vagrantfile
+++ b/romana-install/roles/provision/create-vagrant-hosts/templates/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
 
   # Controller-specific VM configuration
   config.vm.define "{{ stack_name }}-controller" do |controller|
-    config.vm.hostname = "{{ stack_name }}-controller"
+    controller.vm.hostname = "{{ stack_name }}-controller"
     controller.vm.network "private_network", ip: "{{ host_cidr | ipaddr(10) | ipaddr('address') }}"
     controller.vm.provider "virtualbox" do |vb|
       vb.name = "{{ stack_name }}-controller"
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
   # Compute-specific VM configuration
 {% for _ in range(compute_nodes) %}
   config.vm.define "{{ stack_name }}-compute{{ '%02d' | format(loop.index) }}" do |compute|
-    config.vm.hostname = "{{ stack_name }}-compute{{ '%02d' | format(loop.index) }}"
+    compute.vm.hostname = "{{ stack_name }}-compute{{ '%02d' | format(loop.index) }}"
     compute.vm.network "private_network", ip: "{{ host_cidr | ipaddr(10 + loop.index) | ipaddr('address') }}"
     compute.vm.provider "virtualbox" do |vb|
       vb.name = "{{ stack_name }}-compute{{ '%02d' | format(loop.index) }}"

--- a/vagrant_kubernetes.md
+++ b/vagrant_kubernetes.md
@@ -55,7 +55,7 @@ You can now proceed to [Using Romana on Kubernetes](kubernetes_romana.md).
 
 From the same directory, you can perform an uninstall
 ```bash
-./romana-setup -p vagrant -s kubernetes install
+./romana-setup -p vagrant -s kubernetes uninstall
 ```
 
 This will destroy the Kubernetes cluster.


### PR DESCRIPTION
Fix a couple of issues experienced when playing with the Kubernetes on Vagrant version.

Initially the nginx containers of the demo stayed in ContainerCreating state - as romana-ipam was erroring with duplicate entries in the DB, both saying <user>-compute01, this was fixed via the Vagrantfile template correction.

Secondly the kubernetes binary tarball cache is causing the get_url to not be changed & so the extract not run when making a second cluster - the workaround isn't pretty but functional.  Note that the etcd download cache would suffer from the same fate but is broken due to mismatching filenames - left alone for minimum changes (I'm not testing widely).

Also a docs copy-pasta fix.
