### PR TITLE
Release v0.9.3.2

### DIFF
--- a/romana-install/group_vars/all/romana
+++ b/romana-install/group_vars/all/romana
@@ -1,5 +1,5 @@
 # Version
-romana_version: "v0.9.3.1"
+romana_version: "v0.9.3.2"
 romana_core_branch: "{{ romana_version }}"
 romana_kube_branch: "{{ romana_version }}"
 romana_networking_branch: "{{ romana_version }}-stable/liberty"

--- a/test/kubernetes-cluster/frontend-to-backend.yml
+++ b/test/kubernetes-cluster/frontend-to-backend.yml
@@ -5,12 +5,12 @@ metadata:
 spec:
  podSelector:
   matchLabels:
-   role: backend
+   romanaSegment: backend
  ingress:
  - from:
    - podSelector:
       matchLabels:
-       role: frontend
+       romanaSegment: frontend
    ports:
     - protocol: tcp
       port: 80

--- a/test/kubernetes-cluster/tenant-frontend-backend
+++ b/test/kubernetes-cluster/tenant-frontend-backend
@@ -114,7 +114,7 @@ create_deployment() {
 	local image="$2"
 	local segment="$3"
 
-	if ! kubectl run --namespace="$tenant_name" --image="$image" --labels="segment=$segment" "$name"; then
+	if ! kubectl run --namespace="$tenant_name" --image="$image" --labels="romanaSegment=$segment" "$name"; then
 		log_message "Deployment creation problem ($name)"
 		return 1
 	fi
@@ -162,7 +162,7 @@ test_frontend_backend() {
 	log_verbose "Deployments created"
 
 	# Get the backend pod IP
-	backend_ip=$(kubectl --namespace="$tenant_name" get pods --selector="segment=backend" -o json | jq -r '.items[0].status.podIP // empty')
+	backend_ip=$(kubectl --namespace="$tenant_name" get pods --selector="romanaSegment=backend" -o json | jq -r '.items[0].status.podIP // empty')
 	if ! [[ "$backend_ip" ]]; then
 		log_message "Failed to get backend IP"
 		return 1
@@ -170,7 +170,7 @@ test_frontend_backend() {
 	log_verbose "Backend IP is $backend_ip"
 
 	# Get the frontend pod name
-	frontend_podname=$(kubectl --namespace="$tenant_name" get pods --selector="segment=frontend" -o json | jq -r '.items[0].metadata.name // empty')
+	frontend_podname=$(kubectl --namespace="$tenant_name" get pods --selector="romanaSegment=frontend" -o json | jq -r '.items[0].metadata.name // empty')
 	if ! [[ "$frontend_podname" ]]; then
 		log_message "Failed to get frontend podname"
 		return 1


### PR DESCRIPTION
This PR changes the version installed by the installer to v0.9.3.2.

Tests for this release were done on rc.2 with the results below:
Kubernetes: all tests passed
```
016-10-07 04:50:28 (ip-192-168-99-10:clustertests) Test #1: Check that Kubernetes services are running on master : PASSED
2016-10-07 04:50:29 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on master : PASSED
2016-10-07 04:50:30 (ip-192-168-99-10:clustertests) Test #3: Check that Kubernetes services are running on minion : PASSED
2016-10-07 04:50:31 (ip-192-168-99-10:clustertests) Test #4: Check that Romana services are running on minion : PASSED
2016-10-07 04:50:32 (ip-192-168-99-10:clustertests) Test #6: Pull docker containers used in later tests : PASSED
2016-10-07 04:50:55 (ip-192-168-99-10:clustertests) Test #8: Check namespace creation triggers romana tenant creation : PASSED
2016-10-07 04:50:55 (ip-192-168-99-10:clustertests) Test #7: Check that kubernetes can launch some pods : PASSED
2016-10-07 04:51:12 (ip-192-168-99-10:clustertests) Test #9: End-to-End test checking default-allow, isolation and policy-allow : PASSED
2016-10-07 04:50:30 (ip-192-168-99-11:clustertests) Test #3: Check that Kubernetes services are running on minion : PASSED
2016-10-07 04:50:31 (ip-192-168-99-11:clustertests) Test #4: Check that Romana services are running on minion : PASSED
2016-10-07 04:50:32 (ip-192-168-99-11:clustertests) Test #6: Pull docker containers used in later tests : PASSED
```

Devstack: all tests passed
```
2016-10-07 05:25:55 (ip-192-168-99-10:clustertests) Test #1: Check that openstack services are present : PASSED
2016-10-07 05:26:00 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on controller node : PASSED
2016-10-07 05:26:01 (ip-192-168-99-10:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED
2016-10-07 05:26:03 (ip-192-168-99-10:clustertests) Test #4: Check that VMs can be created on each compute node : PASSED
2016-10-07 05:26:23 (ip-192-168-99-10:clustertests) Test #5: End-to-End test checking ping and SSH for VMs in same segment. : PASSED
2016-10-07 05:26:01 (ip-192-168-99-11:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED
```