### PR TITLE
Release v0.9.3.4

### DIFF
--- a/containerize/specs/romana-agent-daemonset.yml
+++ b/containerize/specs/romana-agent-daemonset.yml
@@ -12,7 +12,7 @@ spec:
       hostNetwork: true
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v0.9.3.2
+        image: quay.io/romana/agent:v0.9.3.4
         args:
         # - --romana-root=http://romana-root:9600
         securityContext:

--- a/containerize/specs/romana-services-manifest.yml
+++ b/containerize/specs/romana-services-manifest.yml
@@ -17,7 +17,7 @@ spec:
     - name: db-path
       mountPath: /var/lib/mysql
   - name: romana-services
-    image: quay.io/romana/services:v0.9.3.2
+    image: quay.io/romana/services:v0.9.3.4
     args:
     # - --cidr=10.0.0.0/8
     env:

--- a/containerize/targets/agent/run-romana-agent
+++ b/containerize/targets/agent/run-romana-agent
@@ -354,9 +354,6 @@ true)
 		internal_error "Error flushing chain for NAT rule"
 	fi
 	# Add items to chain
-	if ! iptables -t nat -A ROMANA-MASQ -d "$host_address" -j RETURN; then
-		internal_error "Error adding exclusion for $host_address"
-	fi
 	if ! iptables -t nat -A ROMANA-MASQ -d "$romana_cidr" -j RETURN; then
 		internal_error "Error adding exclusion for $romana_cidr"
 	fi

--- a/romana-install/group_vars/all/romana
+++ b/romana-install/group_vars/all/romana
@@ -1,5 +1,5 @@
 # Version
-romana_version: "v0.9.3.3"
+romana_version: "v0.9.3.4"
 romana_core_branch: "{{ romana_version }}"
 romana_kube_branch: "{{ romana_version }}"
 romana_networking_branch: "{{ romana_version }}-stable/liberty"


### PR DESCRIPTION
This PR releases 0.9.3.4 -- some bug fixes and minor improvements for containerized setups.

Tests are passing on AWS for all stacks.

Kubernetes tests:
```
2016-10-30 23:17:10 (ip-192-168-99-10:clustertests) Test #1: Check that Kubernetes services are running on master : PASSED
2016-10-30 23:17:11 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on master : PASSED
2016-10-30 23:17:13 (ip-192-168-99-10:clustertests) Test #3: Check that Kubernetes services are running on minion : PASSED
2016-10-30 23:17:13 (ip-192-168-99-10:clustertests) Test #4: Check that Romana services are running on minion : PASSED
2016-10-30 23:17:14 (ip-192-168-99-10:clustertests) Test #6: Pull docker containers used in later tests : PASSED
2016-10-30 23:17:35 (ip-192-168-99-10:clustertests) Test #8: Check namespace creation triggers romana tenant creation : PASSED
2016-10-30 23:17:36 (ip-192-168-99-10:clustertests) Test #7: Check that kubernetes can launch some pods : PASSED
2016-10-30 23:17:45 (ip-192-168-99-10:clustertests) Test #9: End-to-End test checking default-allow, isolation and policy-allow : PASSED
2016-10-30 23:17:12 (ip-192-168-99-11:clustertests) Test #3: Check that Kubernetes services are running on minion : PASSED
2016-10-30 23:17:13 (ip-192-168-99-11:clustertests) Test #4: Check that Romana services are running on minion : PASSED
2016-10-30 23:17:14 (ip-192-168-99-11:clustertests) Test #6: Pull docker containers used in later tests : PASSED 
```

Devstack tests
```
2016-10-30 23:35:24 (ip-192-168-99-10:clustertests) Test #1: Check that openstack services are present : PASSED
2016-10-30 23:35:30 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on controller node : PASSED
2016-10-30 23:35:32 (ip-192-168-99-10:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED
2016-10-30 23:35:34 (ip-192-168-99-10:clustertests) Test #4: Check that VMs can be created on each compute node : PASSED
2016-10-30 23:35:55 (ip-192-168-99-10:clustertests) Test #5: End-to-End test checking ping and SSH for VMs in same segment. : PASSED
2016-10-30 23:35:32 (ip-192-168-99-11:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED 
```

Openstack tests
```
2016-10-30 23:22:31 (ip-192-168-99-10:clustertests) Test #1: Check that openstack services are present : PASSED
2016-10-30 23:22:34 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on controller node : PASSED
2016-10-30 23:22:36 (ip-192-168-99-10:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED
2016-10-30 23:22:37 (ip-192-168-99-10:clustertests) Test #4: Check that VMs can be created on each compute node : PASSED
2016-10-30 23:22:51 (ip-192-168-99-10:clustertests) Test #5: End-to-End test checking ping and SSH for VMs in same segment. : PASSED
2016-10-30 23:22:36 (ip-192-168-99-11:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED 
```