### PR TITLE
Release v0.9.3.5

### DIFF
--- a/containerize/specs/romana-agent-daemonset.yml
+++ b/containerize/specs/romana-agent-daemonset.yml
@@ -12,7 +12,7 @@ spec:
       hostNetwork: true
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v0.9.3.4
+        image: quay.io/romana/agent:v0.9.3.5
         args:
         # This IP must match the cluster IP of the romana-root service
         - --romana-root=http://100.64.99.99:9600

--- a/containerize/specs/romana-kops.yml
+++ b/containerize/specs/romana-kops.yml
@@ -23,7 +23,7 @@ spec:
         - name: db-path
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:v0.9.3.4
+        image: quay.io/romana/services:v0.9.3.5
         imagePullPolicy: Always
         args:
         - --cidr=10.192.0.0/10
@@ -66,7 +66,7 @@ spec:
       hostNetwork: true
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v0.9.3.4
+        image: quay.io/romana/agent:v0.9.3.5
         imagePullPolicy: Always
         args:
         - --romana-root=http://100.64.99.99:9600

--- a/containerize/specs/romana-kubeadm.yml
+++ b/containerize/specs/romana-kubeadm.yml
@@ -23,7 +23,7 @@ spec:
         - name: db-path
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:v0.9.3.4
+        image: quay.io/romana/services:v0.9.3.5
         imagePullPolicy: Always
         args:
         - --cidr=100.112.0.0/12
@@ -66,7 +66,7 @@ spec:
       hostNetwork: true
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v0.9.3.4
+        image: quay.io/romana/agent:v0.9.3.5
         imagePullPolicy: Always
         args:
         - --romana-root=http://10.99.99.99:9600

--- a/containerize/specs/romana-services-daemonset.yml
+++ b/containerize/specs/romana-services-daemonset.yml
@@ -28,7 +28,7 @@ spec:
         - name: db-path
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:v0.9.3.4
+        image: quay.io/romana/services:v0.9.3.5
         imagePullPolicy: Always
         args:
         # - --cidr=10.0.0.0/8

--- a/containerize/specs/romana-services-manifest.yml
+++ b/containerize/specs/romana-services-manifest.yml
@@ -17,7 +17,7 @@ spec:
     - name: db-path
       mountPath: /var/lib/mysql
   - name: romana-services
-    image: quay.io/romana/services:v0.9.3.4
+    image: quay.io/romana/services:v0.9.3.5
     args:
     # - --cidr=10.0.0.0/8
     env:

--- a/romana-install/group_vars/all/romana
+++ b/romana-install/group_vars/all/romana
@@ -1,5 +1,5 @@
 # Version
-romana_version: "v0.9.3.4"
+romana_version: "v0.9.3.5"
 romana_core_branch: "{{ romana_version }}"
 romana_kube_branch: "{{ romana_version }}"
 romana_networking_branch: "{{ romana_version }}-stable/liberty"


### PR DESCRIPTION
This PR releases v0.9.3.5, containing some small bug fixes and improvements.

It is passing automated tests.

Kubernetes:
```
2016-11-09 23:18:20 (ip-192-168-99-10:clustertests) Test #1: Check that Kubernetes services are running on master : PASSED
2016-11-09 23:18:20 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on master : PASSED
2016-11-09 23:18:22 (ip-192-168-99-10:clustertests) Test #3: Check that Kubernetes services are running on minion : PASSED
2016-11-09 23:18:23 (ip-192-168-99-10:clustertests) Test #4: Check that Romana services are running on minion : PASSED
2016-11-09 23:18:23 (ip-192-168-99-10:clustertests) Test #6: Pull docker containers used in later tests : PASSED
2016-11-09 23:18:41 (ip-192-168-99-10:clustertests) Test #8: Check namespace creation triggers romana tenant creation : PASSED
2016-11-09 23:18:42 (ip-192-168-99-10:clustertests) Test #7: Check that kubernetes can launch some pods : PASSED
2016-11-09 23:18:57 (ip-192-168-99-10:clustertests) Test #9: End-to-End test checking default-allow, isolation and policy-allow : PASSED
2016-11-09 23:18:22 (ip-192-168-99-11:clustertests) Test #3: Check that Kubernetes services are running on minion : PASSED
2016-11-09 23:18:23 (ip-192-168-99-11:clustertests) Test #4: Check that Romana services are running on minion : PASSED
2016-11-09 23:18:23 (ip-192-168-99-11:clustertests) Test #6: Pull docker containers used in later tests : PASSED 
```

Openstack
```
2016-11-09 23:26:35 (ip-192-168-99-10:clustertests) Test #1: Check that openstack services are present : PASSED
2016-11-09 23:26:38 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on controller node : PASSED
2016-11-09 23:26:40 (ip-192-168-99-10:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED
2016-11-09 23:26:42 (ip-192-168-99-10:clustertests) Test #4: Check that VMs can be created on each compute node : PASSED
2016-11-09 23:26:56 (ip-192-168-99-10:clustertests) Test #5: End-to-End test checking ping and SSH for VMs in same segment. : PASSED
2016-11-09 23:26:40 (ip-192-168-99-11:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED 
```

Devstack
```
2016-11-09 23:36:06 (ip-192-168-99-10:clustertests) Test #1: Check that openstack services are present : PASSED
2016-11-09 23:36:12 (ip-192-168-99-10:clustertests) Test #2: Check that Romana services are running on controller node : PASSED
2016-11-09 23:36:13 (ip-192-168-99-10:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED
2016-11-09 23:36:15 (ip-192-168-99-10:clustertests) Test #4: Check that VMs can be created on each compute node : PASSED
2016-11-09 23:36:37 (ip-192-168-99-10:clustertests) Test #5: End-to-End test checking ping and SSH for VMs in same segment. : PASSED
2016-11-09 23:36:13 (ip-192-168-99-11:clustertests) Test #3: Check that Romana services are running on compute nodes : PASSED 
```
