### PR TITLE
Release v1.0.1

### DIFF
--- a/containerize/specs/romana-agent-daemonset.yml
+++ b/containerize/specs/romana-agent-daemonset.yml
@@ -12,11 +12,11 @@ spec:
       hostNetwork: true
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v1.0.0
+        image: quay.io/romana/agent:v1.0.1
         imagePullPolicy: Always
         args:
         - --cluster-ip-cidr=10.96.0.0/12
-        - --cni-image=quay.io/romana/cni:v1.0.0
+        - --cni-image=quay.io/romana/cni:v1.0.1
         securityContext:
           privileged: true
         volumeMounts:

--- a/containerize/specs/romana-kops.yml
+++ b/containerize/specs/romana-kops.yml
@@ -41,7 +41,7 @@ spec:
         - name: mysql-data
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:v1.0.0
+        image: quay.io/romana/services:v1.0.1
         imagePullPolicy: Always
         args:
         - --cidr=10.192.0.0/10
@@ -93,11 +93,11 @@ spec:
       hostNetwork: true
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v1.0.0
+        image: quay.io/romana/agent:v1.0.1
         imagePullPolicy: Always
         args:
         - --cluster-ip-cidr=100.64.0.0/12
-        - --cni-image=quay.io/romana/cni:v1.0.0
+        - --cni-image=quay.io/romana/cni:v1.0.1
         - --node-name=fqdn
         - --cloud=aws
         securityContext:

--- a/containerize/specs/romana-kubeadm.yml
+++ b/containerize/specs/romana-kubeadm.yml
@@ -1,21 +1,75 @@
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-services
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - pods
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: romana-services
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-services
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: romana-services
+subjects:
+- kind: ServiceAccount
+  name: romana-services
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: romana-secrets
+  namespace: kube-system
+data:
+  datastore-password: cm9tYW5h
+---
 apiVersion: extensions/v1beta1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: romana-services
   namespace: kube-system
 spec:
+  replicas: 1
   template:
     metadata:
       labels:
         app: romana-services
     spec:
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       nodeSelector:
         node-role.kubernetes.io/master: ""
       hostNetwork: true
+      serviceAccountName: romana-services
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: romana-etcd
         image: gcr.io/google_containers/etcd-amd64:3.0.14-kubeadm
@@ -39,18 +93,24 @@ spec:
         image: mysql:5
         env:
         - name: MYSQL_ROOT_PASSWORD
-          value: romana
+          valueFrom:
+            secretKeyRef:
+              name: romana-secrets
+              key: datastore-password
         volumeMounts:
         - name: mysql-data
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:v1.0.0
+        image: quay.io/romana/services:v1.0.1
         imagePullPolicy: Always
         args:
         - --cidr=100.112.0.0/12
         env:
         - name: MYSQL_ROOT_PASSWORD
-          value: romana
+          valueFrom:
+            secretKeyRef:
+              name: romana-secrets
+              key: datastore-password
         volumeMounts:
         - name: log-path
           mountPath: /var/log/romana
@@ -93,13 +153,16 @@ spec:
         app: romana-agent
     spec:
       hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v1.0.0
+        image: quay.io/romana/agent:v1.0.1
         imagePullPolicy: Always
         args:
         - --cluster-ip-cidr=10.96.0.0/12
-        - --cni-image=quay.io/romana/cni:v1.0.0
+        - --cni-image=quay.io/romana/cni:v1.0.1
         securityContext:
           privileged: true
         volumeMounts:

--- a/containerize/specs/romana-services-daemonset.yml
+++ b/containerize/specs/romana-services-daemonset.yml
@@ -46,7 +46,7 @@ spec:
         - name: mysql-data
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:v1.0.0
+        image: quay.io/romana/services:v1.0.1
         imagePullPolicy: Always
         args:
         - --cidr=100.112.0.0/12

--- a/containerize/specs/romana-services-manifest.yml
+++ b/containerize/specs/romana-services-manifest.yml
@@ -17,7 +17,7 @@ spec:
     - name: db-path
       mountPath: /var/lib/mysql
   - name: romana-services
-    image: quay.io/romana/services:v1.0.0
+    image: quay.io/romana/services:v1.0.1
     args:
     # - --cidr=10.0.0.0/8
     env:

--- a/romana-install/group_vars/all/romana
+++ b/romana-install/group_vars/all/romana
@@ -1,5 +1,5 @@
 # Version
-romana_version: "v1.0.0"
+romana_version: "v1.0.1"
 romana_core_branch: "{{ romana_version }}"
 romana_networking_branch: "{{ romana_version }}-stable/liberty"
 

--- a/romana-install/roles/stack/kubeadm/postinstall/files/romana-kubeadm.yml
+++ b/romana-install/roles/stack/kubeadm/postinstall/files/romana-kubeadm.yml
@@ -101,7 +101,7 @@ spec:
         - name: mysql-data
           mountPath: /var/lib/mysql
       - name: romana-services
-        image: quay.io/romana/services:kube16
+        image: quay.io/romana/services:v1.0.1
         imagePullPolicy: Always
         args:
         - --cidr=100.112.0.0/12
@@ -158,11 +158,11 @@ spec:
         effect: NoSchedule
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:kube16
+        image: quay.io/romana/agent:v1.0.1
         imagePullPolicy: Always
         args:
         - --cluster-ip-cidr=10.96.0.0/12
-        - --cni-image=quay.io/romana/cni:kube16
+        - --cni-image=quay.io/romana/cni:v1.0.1
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
This releases version 1.0.1 of Romana.

This is to deliver installation scripts and containers that support kubernetes v1.6.x and installs using kubeadm v1.6.1+.