### PR TITLE
Add seLinuxOptions

### DIFF
--- a/containerize/specs/romana-kops.yml
+++ b/containerize/specs/romana-kops.yml
@@ -106,6 +106,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-services
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -194,6 +197,9 @@ spec:
         app: romana-agent
     spec:
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-agent
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/containerize/specs/romana-kubeadm.yml
+++ b/containerize/specs/romana-kubeadm.yml
@@ -106,6 +106,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-services
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -212,6 +215,9 @@ spec:
         app: romana-agent
     spec:
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-agent
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/romana-install/roles/stack/kubeadm/postinstall/files/romana-kubeadm.yml
+++ b/romana-install/roles/stack/kubeadm/postinstall/files/romana-kubeadm.yml
@@ -106,6 +106,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-services
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -193,6 +196,9 @@ spec:
         app: romana-agent
     spec:
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-agent
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/romana-install/roles/stack/kubeadm/postinstall/templates/romana-localbuild.yml
+++ b/romana-install/roles/stack/kubeadm/postinstall/templates/romana-localbuild.yml
@@ -106,6 +106,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-services
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -193,6 +196,9 @@ spec:
         app: romana-agent
     spec:
       hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       serviceAccountName: romana-agent
       tolerations:
       - key: node-role.kubernetes.io/master


### PR DESCRIPTION
This adds a section to the romana-kubeadm yaml file to specify seLinuxOptions.
On systems with SELinux configured and set to enforcing, some containers were unable to launch because of using paths in `/var`. Those paths weren't permitted by standard selinux policies for docker/kubernetes.

This fixes #169.