### PR TITLE
Use hostNetwork for vpcrouter

### DIFF
--- a/containerize/specs/romana-kops.yml
+++ b/containerize/specs/romana-kops.yml
@@ -338,6 +338,7 @@ spec:
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/docs/kubernetes/romana-kops.yml
+++ b/docs/kubernetes/romana-kops.yml
@@ -338,6 +338,7 @@ spec:
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
The vpcrouter tool uses the AWS API endpoints to make changes to the routing tables within a VPC.
To look up the API endpoint, it needs DNS.

However, kube-dns runs as a service, and some of the the pods providing that service might be running in a different region _before_ vpcrouter has created the routes to access pods there.

It isn't immediately noticeable in some installs, because the first instance of kube-dns runs on a directly-reachable master node.

It becomes a problem when kube-dns is scaled up to more pods - some reachable, some not.

This PR changes the vpcrouter pod to use `hostNetwork: true` to ensure it is always able to look up the AWS API endpoint addresses and bring the pod network into a fully routed state.