### PR TITLE
Merge PR #190 into Legacy Specs

### DIFF
--- a/containerize/specs/romana-kubeadm.yml
+++ b/containerize/specs/romana-kubeadm.yml
@@ -121,6 +121,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
       containers:
       - name: romana-etcd
         image: gcr.io/google_containers/etcd-amd64:3.0.17
@@ -180,6 +182,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
       containers:
       - name: romana-daemon
         image: quay.io/romana/daemon:v2.0.2
@@ -205,6 +209,8 @@ spec:
       serviceAccountName: romana-listener
       tolerations:
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
         effect: NoSchedule
       containers:
       - name: romana-listener
@@ -233,6 +239,8 @@ spec:
       serviceAccountName: romana-agent
       tolerations:
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
         effect: NoSchedule
       containers:
       - name: romana-agent


### PR DESCRIPTION
This copies changes from #190 into legacy version of romana-kubeadm.yml
Otherwise it's not possible to install Romana following instruction from official k8s Docs.